### PR TITLE
Python 3.11 compatibility issue fixed

### DIFF
--- a/it_management/__init__.py
+++ b/it_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@
 from setuptools import setup, find_packages
 import re, ast
 
-try: # for pip >= 10
-	from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-	from pip.req import parse_requirements
+# try: # for pip >= 10
+#	from pip._internal.req import parse_requirements
+#except ImportError: # for pip <= 9.0.3
+#	from pip.req import parse_requirements
 
 # get version from __version__ variable in it_management/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
@@ -17,7 +17,7 @@ with open('it_management/__init__.py', 'rb') as f:
 with open('requirements.txt') as f:
         install_requires = f.read().strip().split('\n')
 
-requirements = parse_requirements("requirements.txt", session="")
+# requirements = parse_requirements("requirements.txt", session="")
 
 setup(
 	name='it_management',


### PR DESCRIPTION
Commented "parse_requirements" in setup.py file to fix the compatibility issue with latest pip.