### PR TITLE
Doctype clean up ITM Landscape and ITM Host Item

### DIFF
--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -11,7 +11,7 @@
   "title",
   "status",
   "serial_number",
-  "itm_it_landscape",
+  "itm_landscape",
   "itm_location"
  ],
  "fields": [
@@ -24,6 +24,7 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "\nImplementing\nRunning\nIssue\nStorage\nObsolet"
   },
@@ -33,21 +34,21 @@
    "label": "Serial Number"
   },
   {
-   "fieldname": "itm_it_landscape",
-   "fieldtype": "Link",
-   "label": "ITM IT Landscape",
-   "options": "ITM IT Landscape"
-  },
-  {
    "fieldname": "itm_location",
    "fieldtype": "Link",
    "label": "ITM Location",
    "options": "ITM Location"
+  },
+  {
+   "fieldname": "itm_landscape",
+   "fieldtype": "Link",
+   "label": "ITM Landscape",
+   "options": "ITM Landscape"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-01-26 12:33:37.031520",
+ "modified": "2024-01-30 10:28:52.371137",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Host Item",

--- a/it_management/it_management/doctype/itm_landscape/itm_landscape.js
+++ b/it_management/it_management/doctype/itm_landscape/itm_landscape.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2024, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('ITM IT Landscape', {
+frappe.ui.form.on('ITM Landscape', {
 	// refresh: function(frm) {
 
 	// }

--- a/it_management/it_management/doctype/itm_landscape/itm_landscape.json
+++ b/it_management/it_management/doctype/itm_landscape/itm_landscape.json
@@ -29,13 +29,13 @@
  "links": [
   {
    "link_doctype": "ITM Host Item",
-   "link_fieldname": "itm_it_landscape"
+   "link_fieldname": "itm_landscape"
   }
  ],
- "modified": "2024-01-22 12:28:07.281366",
+ "modified": "2024-01-30 10:25:19.464775",
  "modified_by": "Administrator",
  "module": "IT Management",
- "name": "ITM IT Landscape",
+ "name": "ITM Landscape",
  "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [

--- a/it_management/it_management/doctype/itm_landscape/itm_landscape.py
+++ b/it_management/it_management/doctype/itm_landscape/itm_landscape.py
@@ -4,5 +4,5 @@
 # import frappe
 from frappe.model.document import Document
 
-class ITMITLandscape(Document):
+class ITMLandscape(Document):
 	pass

--- a/it_management/it_management/doctype/itm_landscape/test_itm_landscape.py
+++ b/it_management/it_management/doctype/itm_landscape/test_itm_landscape.py
@@ -5,5 +5,5 @@
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestITMITLandscape(FrappeTestCase):
+class TestITMLandscape(FrappeTestCase):
 	pass

--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to IT Management App. An app that is built on frappe and can be run without using ERPNext. if desired can be actived for ERPNext thought setting. You will find that each Doctype created for IT Management app carries the prefix ITM to make sure that name duplicates are avoided that you can quickly identify you are navigating in IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your Overall IT overview starts with the ITM IT Landscape. A IT Landscape is linked in the most other DocTypes of this app and will help you nagivate to all the different doctype availableto you and your IT Landscape.\",\"col\":12}},{\"id\":\"0vWI7JIgVu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM IT Landscape\",\"col\":3}},{\"id\":\"MsrvszhZSu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Host Item\",\"col\":3}}]",
+ "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to IT Management App. An app that is built on frappe and can be run without using ERPNext. if desired can be actived for ERPNext thought setting. You will find that each Doctype created for IT Management app carries the prefix ITM to make sure that name duplicates are avoided that you can quickly identify you are navigating in IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your Overall IT overview starts with the ITM IT Landscape. A IT Landscape is linked in the most other DocTypes of this app and will help you nagivate to all the different doctype availableto you and your IT Landscape.\",\"col\":12}},{\"id\":\"0vWI7JIgVu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Landscape\",\"col\":3}},{\"id\":\"MsrvszhZSu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Host Item\",\"col\":3}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -12,7 +12,7 @@
  "is_hidden": 0,
  "label": "IT Management",
  "links": [],
- "modified": "2024-01-22 11:58:41.811606",
+ "modified": "2024-01-30 10:26:57.444627",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",
@@ -27,15 +27,15 @@
   {
    "color": "Grey",
    "doc_view": "List",
-   "label": "ITM IT Landscape",
-   "link_to": "ITM IT Landscape",
+   "label": "ITM Host Item",
+   "link_to": "ITM Host Item",
    "type": "DocType"
   },
   {
    "color": "Grey",
    "doc_view": "List",
-   "label": "ITM Host Item",
-   "link_to": "ITM Host Item",
+   "label": "ITM Landscape",
+   "link_to": "ITM Landscape",
    "type": "DocType"
   }
  ],


### PR DESCRIPTION

#### What does this implement:
Doctype clean up 
ITM Host Item: Display 'name' and 'status' in ItM Host Item list view
ITM IT Landscape: Rename doctype itm it landscape to ITM Landscape 
	rename and make sure doctype field to reflect itm landscape from itm it landscape 
Workspace: Change shortcut name to ITM Landscape and repoint ITM Lanscape shortcut to the right ITM Lanscape Doctype 
![Screenshot from 2024-01-30 10-30-53](https://github.com/phamos-eu/it_management/assets/85407202/b63676fa-b8a6-4432-8442-89714704a756)
![Screenshot from 2024-01-30 10-36-21](https://github.com/phamos-eu/it_management/assets/85407202/107da703-695c-4953-a626-6ca389382e73)
![Screenshot from 2024-01-30 10-38-05](https://github.com/phamos-eu/it_management/assets/85407202/9fad039c-739b-4bf8-8750-e0318e40ec20)
![Screenshot from 2024-01-30 10-44-01](https://github.com/phamos-eu/it_management/assets/85407202/8f3a5f93-a4b1-4e57-aff4-599c5df73379)


