### PR TITLE
ITM Software End of Life checker

### DIFF
--- a/it_management/it_management/doctype/itm_software/itm_software.py
+++ b/it_management/it_management/doctype/itm_software/itm_software.py
@@ -18,3 +18,6 @@ class ITMSoftware(Document):
 			if ddfr <= 0:
 				self.disabled = True
 				self.status = "Outdated"
+			else:
+				self.disabled = False
+				self.status = "Active"

--- a/it_management/it_management/doctype/itm_software/itm_software.py
+++ b/it_management/it_management/doctype/itm_software/itm_software.py
@@ -3,6 +3,18 @@
 
 # import frappe
 from frappe.model.document import Document
+from frappe.utils import cstr, today,date_diff, nowdate
 
 class ITMSoftware(Document):
-	pass
+
+	def validate(self):
+		self.toggle_eof()
+	
+	def toggle_eof(self):
+		
+		if(self.end_of_life):
+			ddfr = date_diff(self.end_of_life, nowdate())
+			#print(ddfr)
+			if ddfr <= 0:
+				self.disabled = True
+				self.status = "Outdated"


### PR DESCRIPTION
End of life: Date fieldtype.
#### What does this implement:
Toggle status of ITM software at point of saving depending upon the date value of the End of Life docfield in comparison with today's date if it's in the future Status of doctype becomes active, if in the past or present Status of doctype becomes Outdated, vis-à-vis the Disabled docfield.