### PR TITLE
Added a backlink from Host Item to Software Instance

### DIFF
--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -47,8 +47,13 @@
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2024-01-30 10:28:52.371137",
+ "links": [
+  {
+   "link_doctype": "ITM Software Instance",
+   "link_fieldname": "itm_host_item"
+  }
+ ],
+ "modified": "2024-02-16 11:47:34.256152",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Host Item",


### PR DESCRIPTION
#### What does this implement:
This Activate the dashboard connection to show the linkage between ITM Software Instance and ITM Host Item and how many instance are connected.

![Instance-backlink](https://github.com/phamos-eu/it_management/assets/85407202/67c3b489-0afe-4108-9e6c-0c1535a67f97)
