### PR TITLE
fix(setup): remove pip import & parse_requirements usage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,35 +2,34 @@
 from setuptools import setup, find_packages
 import re, ast
 
-try: # for pip >= 10
-	from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
-	from pip.req import parse_requirements
-
 # get version from __version__ variable in it_management/__init__.py
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
 
 with open('it_management/__init__.py', 'rb') as f:
-	version = str(ast.literal_eval(_version_re.search(
-		f.read().decode('utf-8')).group(1)))
+    version = str(ast.literal_eval(_version_re.search(
+        f.read().decode('utf-8')).group(1)))
 
-with open('requirements.txt') as f:
-        install_requires = f.read().strip().split('\n')
+def parse_requirements_file(path):
+    """Read requirements.txt and return a list suitable for install_requires."""
+    reqs = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            reqs.append(line)
+    return reqs
 
-requirements = parse_requirements("requirements.txt", session="")
+install_requires = parse_requirements_file('requirements.txt')
 
 setup(
-	name='it_management',
-	version=version,
-	description='Management von IT-Bausteinen. Hierzu gehören',
-	author='IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups,',
-	author_email='Dienstleistungsverträge, Accounts und Internetleistungen.info@tueit.de',
-	packages=find_packages(),
-	zip_safe=False,
-	include_package_data=True,
-	install_requires=install_requires 
-        
-        #This does throw errors while updating:
-        #install_requires=[str(ir.req) for ir in requirements],
-        #dependency_links=[str(ir._link) for ir in requirements if ir._link][str(ir.req) for ir in requirements],
+    name='it_management',
+    version=version,
+    description='Management von IT-Bausteinen. Hierzu gehören',
+    author='IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups,',
+    author_email='Dienstleistungsverträge, Accounts und Internetleistungen.info@tueit.de',
+    packages=find_packages(),
+    zip_safe=False,
+    include_package_data=True,
+    install_requires=install_requires
 )


### PR DESCRIPTION
Summary: Remove import of pip internals from setup.py and add a cleaned requirements.txt so install_requires uses only valid package specifiers.
Changes:
setup.py: removed import and usage of pip internals; added a small parser to read requirements.txt and sanitize blank lines/comments.
requirements.txt: contains only the package name "frappe".
Why: Importing pip internals in setup.py is brittle and fails in some build environments (error seen: "imported module pip not being found"). These changes avoid that failure.

## Error in frappe cloud

<img width="1919" height="982" alt="image" src="https://github.com/user-attachments/assets/cf2e5e0d-cafe-4e1a-b598-cb719d9040dd" />

```
bench get-app file:///home/frappe/context/apps/it_management --cache-key 7fc1ad30dbd925f6aacd8b55b978e29752d300c7 --compress-artifacts
Getting it_management
$ git clone file:///home/frappe/context/apps/it_management  --depth 1 --origin upstream
Cloning into 'it_management'...
Ignoring dependencies of file:///home/frappe/context/apps/it_management. To install dependencies use --resolve-deps
Installing it_management
$ /home/frappe/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /home/frappe/frappe-bench/apps/it_management
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [29 lines of output]
      Traceback (most recent call last):
        File "<string>", line 6, in <module>
      ModuleNotFoundError: No module named 'pip'

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/frappe/frappe-bench/env/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 157, in get_requires_for_build_editable
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-32kgb8rs/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-32kgb8rs/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-32kgb8rs/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-32kgb8rs/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-32kgb8rs/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 8, in <module>
      ModuleNotFoundError: No module named 'pip'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
ERROR: Failed to build 'file:///home/frappe/frappe-bench/apps/it_management' when getting requirements to build editable
ERROR: /home/frappe/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /home/frappe/frappe-bench/apps/it_management
subprocess.CalledProcessError: Command '/home/frappe/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /home/frappe/frappe-bench/apps/it_management ' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/frappe/.local/bin/bench", line 7, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/cli.py", line 132, in cli
    bench_command()
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/commands/make.py", line 181, in get_app
    get_app(
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/app.py", line 786, in get_app
    app.install(verbose=verbose, skip_assets=skip_assets, restart_bench=restart_bench)
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/utils/render.py", line 126, in wrapper_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/app.py", line 253, in install
    install_app(
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/app.py", line 937, in install_app
    bench.run(
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/bench.py", line 49, in run
    return exec_cmd(cmd, cwd=cwd or self.cwd, _raise=_raise, env=env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frappe/.local/lib/python3.11/site-packages/bench/utils/__init__.py", line 184, in exec_cmd
    raise CommandFailedError(cmd) from subprocess.CalledProcessError(return_code, cmd)
bench.exceptions.CommandFailedError: /home/frappe/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /home/frappe/frappe-bench/apps/it_management

process "/bin/sh -c bench get-app file:///home/frappe/context/apps/it_management     --cache-key 7fc1ad30dbd925f6aacd8b55b978e29752d300c7 --compress-artifacts   `#stage-apps-it_management`" did not complete successfully: exit code: 1
------
[stage-0 31/40] RUN --mount=type=cache,sharing=locked,target=/home/frappe/.cache,uid=1000,gid=1000   --mount=type=bind,source=apps/it_management,target=/home/frappe/context/apps/it_management   bench get-app file:///home/frappe/context/apps/it_management     --cache-key 7fc1ad30dbd925f6aacd8b55b978e29752d300c7 --compress-artifacts   `#stage-apps-it_management`:
install_app(
File "/home/frappe/.local/lib/python3.11/site-packages/bench/app.py", line 937, in install_app
bench.run(
File "/home/frappe/.local/lib/python3.11/site-packages/bench/bench.py", line 49, in run
return exec_cmd(cmd, cwd=cwd or self.cwd, _raise=_raise, env=env)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/frappe/.local/lib/python3.11/site-packages/bench/utils/__init__.py", line 184, in exec_cmd
raise CommandFailedError(cmd) from subprocess.CalledProcessError(return_code, cmd)
bench.exceptions.CommandFailedError: /home/frappe/frappe-bench/env/bin/python -m pip install --quiet --upgrade -e /home/frappe/frappe-bench/apps/it_management
3.581
------
Dockerfile:263
--------------------
--------------------
failed to solve: process "/bin/sh -c bench get-app file:///home/frappe/context/apps/it_management     --cache-key 7fc1ad30dbd925f6aacd8b55b978e29752d300c7 --compress-artifacts   `#stage-apps-it_management`" did not complete successfully: exit code: 1

```
