### PR TITLE
fix: remove frappe dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-frappe
+# "frappe>=16.0.0" # Installed and managed by bench.


### PR DESCRIPTION
Frappe is installed and managed by bench, it doesn't need to be specified in requirements.txt.

Removing this makes it_management installable without errors in version-16 and develop.

Closes #284

develop:
<img width="573" height="594" alt="image" src="https://github.com/user-attachments/assets/4b342d9e-ce6e-46e7-918a-f0a6a32628c9" />

version-16:
<img width="573" height="596" alt="image" src="https://github.com/user-attachments/assets/6d2a3ef7-4895-4f74-a2f4-41b805aebc1f" />

ITM on the new Desk:

<img width="882" height="562" alt="image" src="https://github.com/user-attachments/assets/b73bdf23-b06b-48df-9e94-cdf2aaf23e11" />


ITM Workspace: Documents can be created, basic functionality is there, but more thorough testing is needed:

<img width="1290" height="304" alt="image" src="https://github.com/user-attachments/assets/8a5e5446-cee4-41bc-b326-4c2441f24540" />

ITM Landscape Document:

<img width="1165" height="576" alt="image" src="https://github.com/user-attachments/assets/afb42fe8-4e6d-4566-abb7-f7005ee9846a" />

ITM Host Item Document:

<img width="1354" height="747" alt="image" src="https://github.com/user-attachments/assets/c490796e-5e86-4c05-982e-93b6c4d96213" />

