### PR TITLE
Dashboard updates

### DIFF
--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,6 +1,7 @@
 {
+ "app": "it_management",
  "charts": [],
- "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to IT Management App. An app that is built on frappe and can be run without using ERPNext. if desired can be actived for ERPNext thought setting. You will find that each Doctype created for IT Management app carries the prefix ITM to make sure that name duplicates are avoided that you can quickly identify you are navigating in IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your Overall IT overview starts with the ITM IT Landscape. A IT Landscape is linked in the most other DocTypes of this app and will help you nagivate to all the different doctype availableto you and your IT Landscape.\",\"col\":12}},{\"id\":\"0vWI7JIgVu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Landscape\",\"col\":3}},{\"id\":\"MsrvszhZSu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Host Item\",\"col\":3}}]",
+ "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired can be activated for ERPNext through the settings. Each Doctype created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your overall IT overview starts with the ITM Landscape. An IT Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your IT Landscapes.\",\"col\":12}},{\"id\":\"0vWI7JIgVu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Landscape\",\"col\":3}},{\"id\":\"MsrvszhZSu\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"ITM Host Item\",\"col\":3}},{\"id\":\"vQ568QpuUS\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"IT Management Settings\",\"col\":3}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -12,7 +13,7 @@
  "is_hidden": 0,
  "label": "IT Management",
  "links": [],
- "modified": "2024-01-30 10:26:57.444627",
+ "modified": "2026-02-15 17:18:00.352476",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",
@@ -34,10 +35,19 @@
   {
    "color": "Grey",
    "doc_view": "List",
+   "label": "IT Management Settings",
+   "link_to": "IT Management Settings",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
    "label": "ITM Landscape",
    "link_to": "ITM Landscape",
    "type": "DocType"
   }
  ],
- "title": "IT Management"
+ "title": "IT Management",
+ "type": "Workspace"
 }

--- a/it_management/workspace_sidebar/it_management.json
+++ b/it_management/workspace_sidebar/it_management.json
@@ -9,7 +9,7 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "list",
+   "icon": "home",
    "indent": 0,
    "keep_closed": 0,
    "label": "Home",
@@ -21,7 +21,7 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "list",
+   "icon": "computer",
    "indent": 0,
    "keep_closed": 0,
    "label": "ITM Host Item",
@@ -33,7 +33,7 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "list",
+   "icon": "land-plot",
    "indent": 0,
    "keep_closed": 0,
    "label": "ITM Landscape",
@@ -45,7 +45,7 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "list",
+   "icon": "settings",
    "indent": 0,
    "keep_closed": 0,
    "label": "IT Management Settings",
@@ -55,7 +55,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-02-15 17:43:14.290727",
+ "modified": "2026-02-15 18:03:29.176039",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",

--- a/it_management/workspace_sidebar/it_management.json
+++ b/it_management/workspace_sidebar/it_management.json
@@ -1,0 +1,65 @@
+{
+ "app": "it_management",
+ "creation": "2026-02-16 06:23:03.337298",
+ "docstatus": 0,
+ "doctype": "Workspace Sidebar",
+ "header_icon": "setting-gear",
+ "idx": 0,
+ "items": [
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "list",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Home",
+   "link_to": "IT Management",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "list",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "ITM Host Item",
+   "link_to": "ITM Host Item",
+   "link_type": "DocType",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "list",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "ITM Landscape",
+   "link_to": "ITM Landscape",
+   "link_type": "DocType",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "list",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "IT Management Settings",
+   "link_to": "IT Management Settings",
+   "link_type": "DocType",
+   "show_arrow": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2026-02-15 17:43:14.290727",
+ "modified_by": "Administrator",
+ "module": "IT Management",
+ "name": "IT Management",
+ "owner": "Administrator",
+ "standard": 1,
+ "title": "IT Management"
+}

--- a/it_management/workspace_sidebar/it_management.json
+++ b/it_management/workspace_sidebar/it_management.json
@@ -21,11 +21,11 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "computer",
+   "icon": "land-plot",
    "indent": 0,
    "keep_closed": 0,
-   "label": "ITM Host Item",
-   "link_to": "ITM Host Item",
+   "label": "ITM Landscape",
+   "link_to": "ITM Landscape",
    "link_type": "DocType",
    "show_arrow": 0,
    "type": "Link"
@@ -33,11 +33,11 @@
   {
    "child": 0,
    "collapsible": 1,
-   "icon": "land-plot",
+   "icon": "computer",
    "indent": 0,
    "keep_closed": 0,
-   "label": "ITM Landscape",
-   "link_to": "ITM Landscape",
+   "label": "ITM Host Item",
+   "link_to": "ITM Host Item",
    "link_type": "DocType",
    "show_arrow": 0,
    "type": "Link"
@@ -55,7 +55,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-02-15 18:03:29.176039",
+ "modified": "2026-02-15 20:17:02.613914",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",


### PR DESCRIPTION
Contributing grammar fixes for the introduction on the IT Management workspace. Also, I noticed the IT Management Settings are mentioned in the introduction, but they are not easy to find, the only way to get to them might have been the awesomebar. So I added a link to them in the dashboard, next to ITM Landscape and ITM Host Item links.

I also created a standard sidebar for the app that includes all three of those doctypes with helpful sidebar item icons. Here is a screenshot of what it looks like now:

<img width="1329" height="487" alt="image" src="https://github.com/user-attachments/assets/2917e94a-9d0b-4480-a36f-c014d41de4bd" />
