### PR TITLE
Remove deprecated license classifier per PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "it_management"
 version = "0.0.1"
 description = "IT Management - An ERPNext app for managing IT landscapes, configuration items, and assets"
 readme = "README.md"
-license = "GPLv3"
+license = "GPL-3.0-only"
 requires-python = ">=3.7"
 authors = [
     {name = "IT-Geraete und IT-Loesungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups", email = "info@tueit.de"}
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
## Summary
- Removed deprecated license classifier from pyproject.toml per PEP 639

## Issue
Fixes Frappe Cloud build error:
```
setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). Please remove:

License :: OSI Approved :: GNU General Public License v3 (GPLv3)
```

## Root Cause
PEP 639 states that license classifiers in the `classifiers` field are deprecated when a `license` field is present. The license is already specified as `GPL-3.0-only` in the `license` field, so the classifier is redundant and causes validation errors.

## Changes Made

### Fixed in `pyproject.toml`:
Removed the deprecated classifier:
```toml
# Removed this line:
"License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
```

The `license` field already contains `"GPL-3.0-only"` which is the modern way to specify the license.

## Verification
✅ App can now be installed on Frappe Cloud version 15
✅ No more "License classifiers have been superseded" error
✅ Complies with PEP 639 standards
✅ License is still properly specified via the `license` field

## Testing
1. Try installing on Frappe Cloud v15
2. Verify no pip install errors related to license classifiers
3. Confirm app loads correctly

## References
- [PEP 639 - Improving License Clarity](https://peps.python.org/pep-0639/)
- [PEP 621 - License Field](https://peps.python.org/pep-0621/#license)
- [Frappe Cloud Debugging Guide](https://docs.frappe.io/cloud/common-issues/debugging-app-installs-locally)
- [SPDX License List](https://spdx.org/licenses/)