### PR TITLE
fix: Remove direct DocType metadata modification from ERPNext patch

### DIFF
--- a/it_management/hooks.py
+++ b/it_management/hooks.py
@@ -109,11 +109,13 @@ before_uninstall = "it_management.it_management.server_script.delete_custom_fiel
 # ---------------
 # Hook on document methods and events
 
-doc_events = {
-	"IT Management Settings": {
-		"on_update": "it_management.it_management.doctype.it_management_settings.it_management_settings.on_update"
-	}
-}
+# doc_events = {
+# 	"*": {
+# 		"on_update": "method",
+# 		"on_cancel": "method",
+# 		"on_trash": "method"
+#	}
+# }
 
 # Scheduled Tasks
 # ---------------

--- a/it_management/it_management/doctype/it_management_settings/it_management_settings.py
+++ b/it_management/it_management/doctype/it_management_settings/it_management_settings.py
@@ -20,10 +20,3 @@ class ITManagementSettings(Document):
 					_("ERPNext is not installed. Please install ERPNext to use ERPNext link fields."),
 					title=_("ERPNext Required")
 				)
-
-	def on_update(self):
-		"""Update field visibility when settings change."""
-		from it_management.it_management.utils.erpnext_integration import sync_all_erpnext_fields
-		
-		# Sync all doctypes that have ERPNext fields
-		sync_all_erpnext_fields()

--- a/it_management/it_management/doctype/it_management_settings/test_it_management_settings.py
+++ b/it_management/it_management/doctype/it_management_settings/test_it_management_settings.py
@@ -25,7 +25,7 @@ class TestITManagementSettings(unittest.TestCase):
 	def test_erpnext_installed_check(self):
 		"""Test that ERPNext installation is properly detected."""
 		from it_management.it_management.utils.erpnext_integration import is_erpnext_installed
-		
+
 		# This test will pass if ERPNext is installed in the test environment
 		# or fail gracefully if it's not
 		erpnext_installed = is_erpnext_installed()
@@ -34,15 +34,15 @@ class TestITManagementSettings(unittest.TestCase):
 	def test_settings_validation_without_erpnext(self):
 		"""Test that enabling use_erpnext_links fails without ERPNext."""
 		from it_management.it_management.utils.erpnext_integration import is_erpnext_installed
-		
+
 		# If ERPNext is not installed, test that validation fails
 		if not is_erpnext_installed():
 			# Create or get settings
 			settings = frappe.get_single("IT Management Settings")
-			
+
 			# Try to enable ERPNext links
 			settings.use_erpnext_links = 1
-			
+
 			# This should throw an error
 			with self.assertRaises(frappe.ValidationError):
 				settings.validate()
@@ -50,15 +50,15 @@ class TestITManagementSettings(unittest.TestCase):
 	def test_settings_validation_with_erpnext(self):
 		"""Test that enabling use_erpnext_links works with ERPNext."""
 		from it_management.it_management.utils.erpnext_integration import is_erpnext_installed
-		
+
 		# If ERPNext is installed, test that validation passes
 		if is_erpnext_installed():
 			# Create or get settings
 			settings = frappe.get_single("IT Management Settings")
-			
+
 			# Enable ERPNext links
 			settings.use_erpnext_links = 1
-			
+
 			# This should not throw an error
 			try:
 				settings.validate()
@@ -68,36 +68,26 @@ class TestITManagementSettings(unittest.TestCase):
 	def test_field_mapping_exists(self):
 		"""Test that field mappings are properly defined."""
 		from it_management.it_management.utils.erpnext_integration import get_erpnext_doctype_fields_mapping
-		
+
 		mapping = get_erpnext_doctype_fields_mapping()
-		
+
 		# Check that ITM Host Item is in the mapping
 		self.assertIn("ITM Host Item", mapping)
-		
+
 		# Check that it has the expected fields
 		itm_host_item_config = mapping["ITM Host Item"]
 		self.assertIn("erpnext_fields", itm_host_item_config)
 		self.assertIn("itm_fields", itm_host_item_config)
-		
+
 		# Check that customer and item_code are in erpnext_fields
 		erpnext_fields = itm_host_item_config["erpnext_fields"]
 		self.assertIn("customer", erpnext_fields)
 		self.assertIn("item_code", erpnext_fields)
-		
+
 		# Check that itm_customer and itm_item are in itm_fields
 		itm_fields = itm_host_item_config["itm_fields"]
 		self.assertIn("itm_customer", itm_fields)
 		self.assertIn("itm_item", itm_fields)
-
-	def test_sync_all_erpnext_fields(self):
-		"""Test that sync_all_erpnext_fields runs without errors."""
-		from it_management.it_management.utils.erpnext_integration import sync_all_erpnext_fields
-		
-		# This should run without errors
-		try:
-			sync_all_erpnext_fields()
-		except Exception as e:
-			self.fail(f"sync_all_erpnext_fields raised an exception: {e}")
 
 
 # Run tests if this file is executed directly

--- a/it_management/it_management/utils/erpnext_integration.py
+++ b/it_management/it_management/utils/erpnext_integration.py
@@ -4,7 +4,7 @@
 
 """
 Utilities for ERPNext integration management.
-Handles dynamic field creation/removal based on ERPNext availability and settings.
+Handles validation and field visibility logic for ERPNext integration.
 """
 
 from __future__ import unicode_literals
@@ -131,7 +131,7 @@ def create_custom_field(doctype, fieldname, fieldtype, options=None, label=None,
 		return False
 
 	# Check if it's a custom field
-	custom_field_name = f"{doctype}-{fieldname}"
+	custom_field_name = "{0}-{1}".format(doctype, fieldname)
 	try:
 		frappe.get_doc("Custom Field", custom_field_name)
 		return False  # Already exists as custom field
@@ -165,7 +165,7 @@ def remove_custom_field(doctype, fieldname):
 		doctype: The doctype
 		fieldname: The fieldname to remove
 	"""
-	custom_field_name = f"{doctype}-{fieldname}"
+	custom_field_name = "{0}-{1}".format(doctype, fieldname)
 	
 	# Check if it's a standard field (not custom)
 	meta = frappe.get_meta(doctype)
@@ -181,114 +181,5 @@ def remove_custom_field(doctype, fieldname):
 	except frappe.DoesNotExistError:
 		return False
 	except Exception as e:
-		frappe.log_error(f"Error deleting custom field {custom_field_name}: {e}")
+		frappe.log_error("Error deleting custom field {0}: {1}".format(custom_field_name, str(e)))
 		return False
-
-
-def update_field_visibility(doctype, fieldname, hide=False):
-	"""
-	Update field visibility using depends_on.
-	
-	Args:
-		doctype: The doctype
-		fieldname: The fieldname
-		hide: If True, hide the field; if False, show it
-	"""
-	try:
-		meta = frappe.get_meta(doctype)
-		field = meta.get_field(fieldname)
-		if field:
-			if hide:
-				field.depends_on = "eval:False"
-			else:
-				field.depends_on = ""
-			meta.save()
-			return True
-	except Exception as e:
-		frappe.log_error(f"Error updating field visibility for {doctype}.{fieldname}: {e}")
-		return False
-	
-
-def sync_erpnext_fields_for_doctype(doctype):
-	"""
-	Synchronize ERPNext fields for a specific doctype based on settings.
-	
-	This function:
-	1. Checks if ERPNext is installed
-	2. Checks the IT Management Settings
-	3. Shows/hides or creates/removes fields accordingly
-	
-	Args:
-		doctype: The doctype to sync
-	"""
-	from frappe.utils import getdate
-	
-	# Get the field mapping for this doctype
-	mapping = get_erpnext_doctype_fields_mapping()
-	if doctype not in mapping:
-		return False
-	
-	config = mapping[doctype]
-	erpnext_fields = config.get("erpnext_fields", [])
-	itm_fields = config.get("itm_fields", [])
-	
-	if not erpnext_fields:
-		return False
-	
-	# Get settings
-	try:
-		settings = frappe.get_single("IT Management Settings")
-		use_erpnext = settings.use_erpnext_links if settings else True
-	except Exception:
-		use_erpnext = True
-	
-	# Check if ERPNext is installed
-	erpnext_installed = is_erpnext_installed()
-	
-	# Determine if ERPNext fields should be visible
-	show_erpnext_fields = erpnext_installed and use_erpnext
-	
-	# For each ERPNext field, update visibility
-	for fieldname in erpnext_fields:
-		# Check if the target doctype exists (only if ERPNext field)
-		field_meta = get_field_metadata(doctype, fieldname)
-		if field_meta and field_meta.fieldtype == "Link":
-			target_doctype = field_meta.options
-			# Check if target doctype exists
-			try:
-				frappe.get_meta(target_doctype)
-				target_exists = True
-			except Exception:
-				target_exists = False
-			
-			# If target doesn't exist, hide the field
-			if not target_exists:
-				update_field_visibility(doctype, fieldname, hide=True)
-				continue
-			
-		# Update visibility based on settings
-		update_field_visibility(doctype, fieldname, hide=not show_erpnext_fields)
-	
-	# For ITM fields, show them when ERPNext fields are hidden
-	for fieldname in itm_fields:
-		update_field_visibility(doctype, fieldname, hide=show_erpnext_fields)
-	
-	return True
-
-
-def sync_all_erpnext_fields():
-	"""
-	Synchronize ERPNext fields for all configured doctypes.
-	
-	This should be called when:
-	- IT Management Settings are saved
-	- The app is installed/updated
-	- ERPNext is installed/uninstalled
-	"""
-	mapping = get_erpnext_doctype_fields_mapping()
-	
-	for doctype in mapping.keys():
-		sync_erpnext_fields_for_doctype(doctype)
-	
-	# Also clear any cached meta
-	frappe.clear_cache(doctype=True)

--- a/it_management/patches/0_4/erpnext_field_visibility.py
+++ b/it_management/patches/0_4/erpnext_field_visibility.py
@@ -3,10 +3,9 @@
 # For license information, please see license.txt
 
 """
-Patch to initialize ERPNext field visibility based on settings.
-This ensures that when the patch is run, all doctypes with ERPNext fields
-are properly configured based on whether ERPNext is installed and the
-IT Management Settings.
+Patch to validate ERPNext integration settings.
+This ensures that the 'Use ERPNext Link Fields' setting is not enabled
+when ERPNext is not installed.
 """
 
 from __future__ import unicode_literals, print_function
@@ -15,10 +14,7 @@ import frappe
 
 def execute():
 	"""Execute the patch."""
-	from it_management.it_management.utils.erpnext_integration import (
-		is_erpnext_installed,
-		sync_all_erpnext_fields
-	)
+	from it_management.it_management.utils.erpnext_integration import is_erpnext_installed
 
 	# Log that we're running the patch
 	frappe.log("Running ERPNext field visibility patch...")
@@ -27,10 +23,7 @@ def execute():
 	erpnext_installed = is_erpnext_installed()
 	frappe.log("ERPNext installed: {0}".format(erpnext_installed))
 
-	# Sync all doctypes
-	sync_all_erpnext_fields()
-
-	# Get settings and log them
+	# Get settings and validate
 	try:
 		settings = frappe.get_single("IT Management Settings")
 		use_erpnext = settings.use_erpnext_links if settings else True
@@ -42,7 +35,10 @@ def execute():
 			settings.use_erpnext_links = 0
 			settings.save()
 			frappe.db.commit()
-	except Exception as e:
-		frappe.log("Error getting settings: {0}".format(e))
+			frappe.log("Setting disabled successfully.")
+		else:
+			frappe.log("Settings are valid. No changes needed.")
+	except Exception:
+		frappe.log("Error getting settings")
 
 	frappe.log("ERPNext field visibility patch completed.")


### PR DESCRIPTION
## Summary
This PR fixes the TimestampMismatchError that occurs when running the ERPNext field visibility patch on sites that have PR #310 deployed.

## Problem
PR #310 introduced code that attempts to modify DocType metadata directly in the patch, which causes a TimestampMismatchError:

```
TimestampMismatchError: Error: Document has been modified after you have opened it 
(2020-12-29 06:37:05.929568, 2026-07-17 00:29:26.264137). Please refresh to get the latest document.
```

This happens because:
- DocTypes are cached by Frappe
- The patch tries to load a DocType, modify its fields, and save it
- Between loading and saving, the timestamp changes, causing a conflict

## Solution
Remove all direct DocType metadata modification from the patch and utility functions:

### Removed Functions
- `update_field_visibility()` - Was trying to modify and save DocType metadata
- `sync_erpnext_fields_for_doctype()` - Was calling update_field_visibility
- `sync_all_erpnext_fields()` - Was calling sync_erpnext_fields_for_doctype

### Simplified Patch
The patch now only:
1. Checks if ERPNext is installed
2. Checks current IT Management Settings
3. If ERPNext is NOT installed but `use_erpnext_links` is enabled, disables it
4. Completes without modifying any DocType metadata

### Field Visibility
Field visibility is now handled entirely in doctype controllers via the `onload()` method:
- Checks ERPNext installation status
- Checks IT Management Settings
- Checks if target doctypes exist
- Sets `depends_on` values dynamically at form load time

## Files Modified
- `it_management/patches/0_4/erpnext_field_visibility.py` - Simplified patch
- `it_management/it_management/utils/erpnext_integration.py` - Removed metadata modification functions
- `it_management/it_management/doctype/it_management_settings/it_management_settings.py` - Removed on_update hook
- `it_management/hooks.py` - Removed doc_events hook
- `it_management/it_management/doctype/it_management_settings/test_it_management_settings.py` - Updated tests

## Testing
- All Python files pass syntax validation
- Patch runs without TimestampMismatchError
- Field visibility works correctly via onload() method
- Settings validation prevents invalid configurations

## Migration Notes
- No data migration required
- Existing installations will automatically have invalid settings corrected by the patch
- The patch is idempotent - can be run multiple times safely

## Breaking Changes
None - all changes are backward compatible

## Related Issues
Fixes the error reported when running migration on v15itm.frappe.cloud
