### PR TITLE
fix: Use Page DocType for v15 compatibility

### DIFF
--- a/it_management/hooks.py
+++ b/it_management/hooks.py
@@ -149,9 +149,3 @@ before_uninstall = "it_management.it_management.server_script.delete_custom_fiel
 override_whitelisted_methods = {
 	"it_management.api.get_landscape_graph_data": "it_management.api.get_landscape_graph_data"
 }
-
-# Website Route Rules
-# --------------------
-website_route_rules = [
-	{"from_route": "/it-landscape-graph", "to_route": "www/it_landscape_graph.html"}
-]

--- a/it_management/patches/0_4/add_landscape_graph_link.py
+++ b/it_management/patches/0_4/add_landscape_graph_link.py
@@ -6,10 +6,33 @@ import frappe
 
 def execute():
 	"""
-	Add IT Landscape Graph link to the IT Management workspace sidebar.
+	Create a Page for IT Landscape Graph and add link to IT Management workspace.
 	Compatible with Frappe v15 and v16.
 	"""
-	# Check if the workspace exists
+	# Step 1: Create the Page DocType record
+	page_name = "it-landscape-graph"
+	if not frappe.db.exists("Page", page_name):
+		page = frappe.get_doc({
+			"doctype": "Page",
+			"name": page_name,
+			"title": "IT Landscape Graph",
+			"route": "/it-landscape-graph",
+			"module": "IT Management",
+			"is_virtual_page": 0,
+			"script": """
+// Redirect to the actual HTML file
+window.location.href = '/assets/it_management/www/it_landscape_graph.html';
+""",
+			"is_single": 0,
+			"published": 1
+		})
+		page.insert(ignore_permissions=True)
+		frappe.db.commit()
+		frappe.log(f"Created Page: {page_name}")
+	else:
+		frappe.log(f"Page {page_name} already exists")
+
+	# Step 2: Add link to IT Management workspace
 	workspace_name = "IT Management"
 	if not frappe.db.exists("Workspace", workspace_name):
 		frappe.log(f"Workspace '{workspace_name}' not found, skipping link addition")
@@ -19,7 +42,7 @@ def execute():
 
 	# Check if the link already exists
 	link_exists = any(
-		link.get("link_to") == "/app/it-landscape-graph"
+		link.get("link_to") == page_name
 		for link in workspace.get("links", [])
 	)
 
@@ -29,14 +52,14 @@ def execute():
 
 	# Add the link to the workspace
 	# In v15, workspace links use "link_type", "link_to", "label"
+	# link_to should be the Page name, not the URL
 	new_link = {
 		"link_type": "Page",
-		"link_to": "/app/it-landscape-graph",
+		"link_to": page_name,  # This is the Page name, not the URL
 		"label": "IT Landscape Graph",
-		"idx": 10  # Position in the sidebar
+		"idx": 10
 	}
 
-	# In v15, we append directly to the links list
 	workspace.append("links", new_link)
 	workspace.save(ignore_permissions=True)
 	


### PR DESCRIPTION
## Summary
Fixes the migration error in Frappe v15 when running the IT Landscape Graph patch.

## Problem
The previous implementation tried to add a workspace link directly to a URL (`/app/it-landscape-graph`), but Frappe v15 validates that workspace links must reference an **existing Page DocType**. This caused a `LinkValidationError: Could not find Row #10: Link To: /app/it-landscape-graph`.

## Solution
1. **Create a Page DocType** record named `it-landscape-graph` that redirects to the actual HTML file
2. **Update the patch** to:
   - First create the Page DocType
   - Then add the workspace link referencing the Page name (not the URL)
3. **Remove `website_route_rules`** from hooks.py (no longer needed since we're using a Page)

## Changes

### Modified Files
- `it_management/hooks.py` - Removed `website_route_rules` (using Page DocType instead)
- `it_management/patches/0_4/add_landscape_graph_link.py` - Updated to create Page first, then add workspace link

## Testing
After merging and deploying:
1. Run patches: `bench migrate` or `bench update`
2. The patch will:
   - Create a Page named `it-landscape-graph`
   - Add a link to the IT Management workspace sidebar
3. Access the graph at: `/app/it-landscape-graph`
4. The link should appear in the IT Management workspace

## Notes
- Compatible with Frappe v15 and v16
- The Page uses a simple JavaScript redirect to serve the HTML file from `www/`
- This is the standard Frappe v15 approach for custom pages

Fixes #it-landscape-graph
