### PR TITLE
fix: add_landscape_graph_link patch - use page_name field

### DIFF
--- a/it_management/patches/0_4/add_landscape_graph_link.py
+++ b/it_management/patches/0_4/add_landscape_graph_link.py
@@ -14,7 +14,7 @@ def execute():
 	if not frappe.db.exists("Page", page_name):
 		page = frappe.get_doc({
 			"doctype": "Page",
-			"name": page_name,
+			"page_name": page_name,  # Set page_name, not name - this is what autoname uses
 			"title": "IT Landscape Graph",
 			"route": "/it-landscape-graph",
 			"module": "IT Management",


### PR DESCRIPTION
## Summary
Fix migration error in add_landscape_graph_link patch

## Business Context
Bench migration was failing with:
```
AttributeError: 'NoneType' object has no attribute 'lower'
  at frappe/core/doctype/page/page.py:45 in autoname
```

This occurred when running the `add_landscape_graph_link` patch during migration.

## Technical Changes
Fixed the `add_landscape_graph_link.py` patch to correctly create the Page document.

**Root Cause:** The Page doctype in Frappe has an `autoname` method that uses `self.page_name` to generate `self.name`. The patch was setting `name` directly but not `page_name`, causing `page_name` to be `None`.

**Fix:** Changed line 17 from `"name": page_name` to `"page_name": page_name`

## Migration Notes
- Users who have already run the broken patch may need to manually clean up
- The patch is idempotent - it checks if the Page already exists before creating

## Deployment Steps
1. Pull this branch
2. Run `bench update` or `bench restart`
3. Run `bench migrate` to execute the fixed patch

## Testing Performed
- Verified the patch logic is correct
- Confirmed page_name field is set before autoname is called

## Breaking Changes
None

## Rollback Plan
Revert to previous commit if issues arise.

## Reviewer Notes
This is a minimal one-line fix that resolves the migration error. The null bytes issue appears to already be fixed in develop.
