### PR TITLE
fix: settings-driven ERPNext Custom Fields for ITM Host Item (data-safe)

### DIFF
--- a/it_management/it_management/doctype/it_management_settings/it_management_settings.py
+++ b/it_management/it_management/doctype/it_management_settings/it_management_settings.py
@@ -11,18 +11,23 @@ from frappe import _
 class ITManagementSettings(Document):
 	def validate(self):
 		"""Validate settings before saving."""
-		# Validate ERPNext is installed when enabling ERPNext links
 		if self.use_erpnext_links:
 			from it_management.it_management.utils.erpnext_integration import is_erpnext_installed
-			
+
 			if not is_erpnext_installed():
 				frappe.throw(
 					_("ERPNext is not installed. Please install ERPNext to use ERPNext link fields."),
-					title=_("ERPNext Required")
+					title=_("ERPNext Required"),
 				)
 
 	def on_update(self):
-		"""Keep ERPNext Link field meta safe for the current install."""
-		from it_management.it_management.utils.erpnext_integration import sync_erpnext_link_fields
+		"""Create/retire ERPNext Custom Fields and neutralize remaining Links."""
+		from it_management.it_management.utils.erpnext_integration import (
+			sync_erpnext_custom_fields,
+			sync_erpnext_link_fields,
+		)
 
+		# Managed DocTypes (ITM Host Item): Custom Fields driven by this toggle
+		sync_erpnext_custom_fields()
+		# Other DocTypes still shipping standard Links: Property Setter safety net
 		sync_erpnext_link_fields()

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -12,10 +12,8 @@
   "status",
   "serial_number",
   "customer_section",
-  "customer",
   "itm_customer",
   "item_section",
-  "item_code",
   "itm_item",
   "itm_landscape",
   "itm_location",
@@ -48,13 +46,6 @@
    "collapsible": 1
   },
   {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "label": "Customer",
-   "options": "Customer",
-   "depends_on": "eval:false"
-  },
-  {
    "fieldname": "itm_customer",
    "fieldtype": "Link",
    "label": "ITM Customer",
@@ -65,13 +56,6 @@
    "fieldtype": "Section Break",
    "label": "Item",
    "collapsible": 1
-  },
-  {
-   "fieldname": "item_code",
-   "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
-   "depends_on": "eval:false"
   },
   {
    "fieldname": "itm_item",
@@ -111,7 +95,7 @@
    "link_fieldname": "itm_host_item"
   }
  ],
- "modified": "2026-04-06 12:07:29.739521",
+ "modified": "2026-07-18 14:00:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Host Item",

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.py
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.py
@@ -8,71 +8,40 @@ from frappe import _
 
 class ITMHostItem(Document):
 	def onload(self):
-		"""Show ERPNext or ITM link fields based on install + settings."""
+		"""Hide ITM link fields while ERPNext Link Custom Fields are active."""
 		from it_management.it_management.utils.erpnext_integration import (
-			is_erpnext_installed,
+			use_erpnext_link_fields,
 			get_erpnext_doctype_fields_mapping,
 		)
 
-		try:
-			settings = frappe.get_single("IT Management Settings")
-			use_erpnext = settings.use_erpnext_links if settings else False
-		except Exception:
-			use_erpnext = False
-
-		show_erpnext_fields = is_erpnext_installed() and use_erpnext
-		config = get_erpnext_doctype_fields_mapping().get("ITM Host Item", {})
-		erpnext_fields = config.get("erpnext_fields", [])
-		itm_fields = config.get("itm_fields", [])
+		show_erpnext_fields = use_erpnext_link_fields()
+		itm_fields = (
+			get_erpnext_doctype_fields_mapping()
+			.get("ITM Host Item", {})
+			.get("itm_fields", [])
+		)
 
 		if not (hasattr(self, "meta") and hasattr(self.meta, "get_field")):
 			return
 
-		for fieldname in erpnext_fields:
-			field = self.meta.get_field(fieldname)
-			if not field:
-				continue
-
-			target_exists = False
-			if field.fieldtype == "Link" and field.options and field.options != "[Select]":
-				try:
-					frappe.get_meta(field.options)
-					target_exists = True
-				except Exception:
-					target_exists = False
-
-			if target_exists and show_erpnext_fields:
-				field.depends_on = ""
-			else:
-				field.depends_on = "eval:False"
-
 		for fieldname in itm_fields:
 			field = self.meta.get_field(fieldname)
-			if not field:
-				continue
-			field.depends_on = "eval:False" if show_erpnext_fields else ""
+			if field:
+				field.depends_on = "eval:False" if show_erpnext_fields else ""
 
 	def validate(self):
-		"""Validate ERPNext link targets when those fields are in use."""
+		"""Validate ERPNext link targets when those Custom Fields are in use."""
 		from it_management.it_management.utils.erpnext_integration import (
-			is_erpnext_installed,
+			use_erpnext_link_fields,
 			get_erpnext_doctype_fields_mapping,
 		)
 
-		try:
-			settings = frappe.get_single("IT Management Settings")
-			use_erpnext = settings.use_erpnext_links if settings else False
-		except Exception:
-			use_erpnext = False
-
-		show_erpnext_fields = is_erpnext_installed() and use_erpnext
-		erpnext_fields = (
-			get_erpnext_doctype_fields_mapping()
-			.get("ITM Host Item", {})
-			.get("erpnext_fields", [])
-		)
-
-		if show_erpnext_fields:
+		if use_erpnext_link_fields():
+			erpnext_fields = (
+				get_erpnext_doctype_fields_mapping()
+				.get("ITM Host Item", {})
+				.get("erpnext_fields", [])
+			)
 			for fieldname in erpnext_fields:
 				value = self.get(fieldname)
 				if not value:
@@ -91,7 +60,6 @@ class ITMHostItem(Document):
 						title=_("Missing Doctype"),
 					)
 
-		# Validate solution relationships - prevent duplicate solutions
 		if self.get("itm_host_item_solution_table"):
 			solutions = [
 				row.itm_solution

--- a/it_management/it_management/utils/erpnext_integration.py
+++ b/it_management/it_management/utils/erpnext_integration.py
@@ -4,10 +4,17 @@
 
 """
 Utilities for ERPNext integration management.
-Handles validation and field visibility logic for ERPNext integration.
+
+ERPNext Link fields (Customer, Item, …) are optional:
+- Fresh DocType JSON does not ship them for managed DocTypes (ITM Host Item).
+- They are created as Custom Fields when ERPNext is installed and
+  IT Management Settings.use_erpnext_links is enabled.
+- Disabling the setting removes empty Link Custom Fields, or converts valued
+  ones to Data so values are never dropped.
 """
 
 from __future__ import unicode_literals
+
 import frappe
 from frappe import _
 
@@ -16,7 +23,7 @@ def is_erpnext_installed():
 	"""Check if ERPNext app is installed."""
 	try:
 		installed_apps = frappe.get_installed_apps()
-		return 'erpnext' in installed_apps
+		return "erpnext" in installed_apps
 	except Exception:
 		return False
 
@@ -26,14 +33,14 @@ def validate_erpnext_required():
 	if not is_erpnext_installed():
 		frappe.throw(
 			_("ERPNext is not installed. Please install ERPNext to use this feature."),
-			title=_("ERPNext Required")
+			title=_("ERPNext Required"),
 		)
 
 
 def get_erpnext_doctype_fields_mapping():
 	"""
 	Get mapping of doctypes and their ERPNext/ITM field pairs.
-	
+
 	Returns:
 		dict: {
 			"ITM Host Item": {
@@ -46,77 +53,117 @@ def get_erpnext_doctype_fields_mapping():
 	return {
 		"ITM Host Item": {
 			"erpnext_fields": ["customer", "item_code"],
-			"itm_fields": ["itm_customer", "itm_item"]
+			"itm_fields": ["itm_customer", "itm_item"],
 		},
 		"Software Instance": {
 			"erpnext_fields": ["customer", "supplier"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"Configuration Item": {
 			"erpnext_fields": ["customer", "item_code", "supplier"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"IT Hardware": {
 			"erpnext_fields": ["item_code"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"Licence": {
 			"erpnext_fields": ["item_code", "supplier"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"ITM User Account": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"User Account": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"Subnet Table": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"Location Room": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"ITM Solution Table": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"User Group Table": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"IT Checklist Table": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"Solution Table": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
+			"itm_fields": [],
 		},
 		"ITM Solution": {
 			"erpnext_fields": ["customer"],
-			"itm_fields": []
-		}
+			"itm_fields": [],
+		},
 	}
+
+
+# DocTypes whose ERPNext Links are managed as Custom Fields (not in JSON).
+# Extend this map as more DocTypes are migrated off standard Link fields.
+MANAGED_ERPNEXT_CUSTOM_FIELDS = {
+	"ITM Host Item": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "customer_section",
+		},
+		"item_code": {
+			"label": "Item",
+			"options": "Item",
+			"insert_after": "item_section",
+		},
+	}
+}
+
+ERPNEXT_CF_MODULE = "IT Management"
+
+
+def use_erpnext_link_fields():
+	"""True when ERPNext is installed and the settings toggle is enabled."""
+	if not is_erpnext_installed():
+		return False
+	try:
+		settings = frappe.get_single("IT Management Settings")
+		return bool(settings.use_erpnext_links) if settings else False
+	except Exception:
+		return False
 
 
 def get_field_metadata(doctype, fieldname):
 	"""Get field metadata from doctype."""
 	try:
 		meta = frappe.get_meta(doctype)
-		field = meta.get_field(fieldname)
-		return field
+		return meta.get_field(fieldname)
 	except Exception:
 		return None
+
+
+def get_custom_field(doctype, fieldname):
+	"""Return Custom Field doc for dt/fieldname, or None."""
+	name = frappe.db.get_value(
+		"Custom Field", {"dt": doctype, "fieldname": fieldname}, "name"
+	)
+	if not name:
+		return None
+	return frappe.get_doc("Custom Field", name)
 
 
 def create_custom_field(doctype, fieldname, fieldtype, options=None, label=None, **kwargs):
 	"""
 	Create a custom field if it doesn't exist.
-	
+
 	Args:
 		doctype: The doctype to add the field to
 		fieldname: The fieldname
@@ -125,69 +172,292 @@ def create_custom_field(doctype, fieldname, fieldtype, options=None, label=None,
 		label: The field label
 		**kwargs: Additional field properties
 	"""
-	# Check if field already exists in the doctype
-	meta = frappe.get_meta(doctype)
+	meta = frappe.get_meta(doctype, cached=False)
 	if meta.has_field(fieldname):
 		return False
 
-	# Check if it's a custom field
-	custom_field_name = "{0}-{1}".format(doctype, fieldname)
-	try:
-		frappe.get_doc("Custom Field", custom_field_name)
-		return False  # Already exists as custom field
-	except frappe.DoesNotExistError:
-		pass
+	if get_custom_field(doctype, fieldname):
+		return False
 
-	# Create the custom field
 	custom_field = frappe.new_doc("Custom Field")
 	custom_field.dt = doctype
 	custom_field.fieldname = fieldname
 	custom_field.fieldtype = fieldtype
 	custom_field.label = label or fieldname
-	
+	custom_field.module = kwargs.pop("module", ERPNEXT_CF_MODULE)
+
 	if options:
 		custom_field.options = options
-	
-	# Set common properties
+
 	for key, value in kwargs.items():
 		if hasattr(custom_field, key):
 			setattr(custom_field, key, value)
-	
+
 	custom_field.insert(ignore_permissions=True)
+	frappe.clear_cache(doctype=doctype)
 	return True
 
 
 def remove_custom_field(doctype, fieldname):
+	"""Remove a custom field if it exists (never touches standard fields)."""
+	custom_field = get_custom_field(doctype, fieldname)
+	if not custom_field:
+		return False
+
+	frappe.delete_doc("Custom Field", custom_field.name, force=1, ignore_permissions=True)
+	frappe.clear_cache(doctype=doctype)
+	return True
+
+
+def _table_name(doctype):
+	return "tab{0}".format(doctype)
+
+
+def _nonempty_value_count(doctype, fieldname):
+	"""Count rows with a non-empty value in the column (0 if column missing)."""
+	if not frappe.db.has_column(doctype, fieldname):
+		return 0
+	table = _table_name(doctype)
+	return frappe.db.sql(
+		"SELECT COUNT(*) FROM `{0}` WHERE IFNULL(`{1}`, '') != ''".format(table, fieldname)
+	)[0][0]
+
+
+def _remove_standard_docfield(doctype, fieldname):
+	"""Remove a standard DocField from the DocType (runs under in_patch)."""
+	if not frappe.db.exists("DocType", doctype):
+		return False
+
+	doc = frappe.get_doc("DocType", doctype)
+	removed = False
+	for df in list(doc.fields):
+		if df.fieldname == fieldname:
+			doc.remove(df)
+			removed = True
+
+	if isinstance(doc.field_order, list) and fieldname in doc.field_order:
+		doc.field_order = [f for f in doc.field_order if f != fieldname]
+		removed = True
+	elif isinstance(doc.field_order, str) and fieldname in doc.field_order:
+		# Older sites may store field_order as text
+		order = [f.strip() for f in doc.field_order.split(",") if f.strip()]
+		if fieldname in order:
+			doc.field_order = [f for f in order if f != fieldname]
+			removed = True
+
+	if not removed:
+		return False
+
+	doc.flags.ignore_validate = True
+	doc.save(ignore_permissions=True)
+	frappe.clear_cache(doctype=doctype)
+	return True
+
+
+def _is_standard_docfield(doctype, fieldname):
+	"""True if fieldname is defined on the DocType document (not only Custom Field)."""
+	return bool(
+		frappe.db.exists("DocField", {"parent": doctype, "fieldname": fieldname})
+	)
+
+
+def migrate_standard_erpnext_link_field(doctype, fieldname, label=None):
 	"""
-	Remove a custom field if it exists.
-	
+	Data-safe removal of a standard ERPNext Link field before model sync.
+
+	- If the column has values: preserve them as a Data Custom Field (same name).
+	- If empty: drop the standard DocField only.
+	"""
+	if not frappe.db.exists("DocType", doctype):
+		return "skipped-missing-doctype"
+
+	_delete_erpnext_link_property_setters(doctype, fieldname)
+
+	custom = get_custom_field(doctype, fieldname)
+	standard = _is_standard_docfield(doctype, fieldname)
+
+	if not standard:
+		# Already migrated / never present as standard field
+		if custom:
+			return "already-custom"
+		return "absent"
+
+	label = label or fieldname.replace("_", " ").title()
+	table = _table_name(doctype)
+	tmp_col = "_{0}_mig".format(fieldname)
+	value_count = _nonempty_value_count(doctype, fieldname)
+
+	if value_count:
+		# Move valued column aside so DocType save / later sync cannot drop data
+		if frappe.db.has_column(doctype, tmp_col):
+			frappe.db.sql_ddl("ALTER TABLE `{0}` DROP COLUMN `{1}`".format(table, tmp_col))
+
+		frappe.db.sql_ddl(
+			"ALTER TABLE `{0}` CHANGE `{1}` `{2}` varchar(140)".format(
+				table, fieldname, tmp_col
+			)
+		)
+
+		_remove_standard_docfield(doctype, fieldname)
+
+		# Custom Field insert recreates `fieldname` column
+		if get_custom_field(doctype, fieldname):
+			remove_custom_field(doctype, fieldname)
+
+		create_custom_field(
+			doctype,
+			fieldname,
+			"Data",
+			label=label,
+			module=ERPNEXT_CF_MODULE,
+		)
+
+		if frappe.db.has_column(doctype, fieldname) and frappe.db.has_column(doctype, tmp_col):
+			frappe.db.sql(
+				"UPDATE `{0}` SET `{1}` = `{2}`".format(table, fieldname, tmp_col)
+			)
+			frappe.db.sql_ddl("ALTER TABLE `{0}` DROP COLUMN `{1}`".format(table, tmp_col))
+
+		return "preserved-as-data"
+
+	# Empty column: safe to remove standard field (sync would drop it anyway)
+	_remove_standard_docfield(doctype, fieldname)
+	return "removed-empty"
+
+
+def ensure_erpnext_link_custom_field(doctype, fieldname, spec):
+	"""Ensure a Link Custom Field exists (upgrade Data → Link when enabling)."""
+	options = spec.get("options")
+	label = spec.get("label") or fieldname
+	insert_after = spec.get("insert_after")
+
+	custom = get_custom_field(doctype, fieldname)
+	if custom:
+		changed = False
+		if custom.fieldtype != "Link":
+			custom.fieldtype = "Link"
+			changed = True
+		if custom.options != options:
+			custom.options = options
+			changed = True
+		if label and custom.label != label:
+			custom.label = label
+			changed = True
+		if insert_after and custom.insert_after != insert_after:
+			custom.insert_after = insert_after
+			changed = True
+		if changed:
+			custom.save(ignore_permissions=True)
+			frappe.clear_cache(doctype=doctype)
+			return "upgraded-to-link"
+		return "exists"
+
+	if _is_standard_docfield(doctype, fieldname):
+		# Should have been migrated already; do not create a conflicting CF
+		return "blocked-by-standard"
+
+	kwargs = {"module": ERPNEXT_CF_MODULE}
+	if insert_after:
+		kwargs["insert_after"] = insert_after
+
+	created = create_custom_field(
+		doctype,
+		fieldname,
+		"Link",
+		options=options,
+		label=label,
+		**kwargs
+	)
+	return "created" if created else "skipped"
+
+
+def retire_erpnext_link_custom_field(doctype, fieldname):
+	"""
+	When disabling ERPNext links:
+	- valued Link/Data Custom Field → keep as Data
+	- empty Custom Field → delete
+	"""
+	custom = get_custom_field(doctype, fieldname)
+	if not custom:
+		return "absent"
+
+	value_count = _nonempty_value_count(doctype, fieldname)
+	if value_count:
+		if custom.fieldtype != "Data" or custom.options:
+			custom.fieldtype = "Data"
+			custom.options = ""
+			custom.save(ignore_permissions=True)
+			frappe.clear_cache(doctype=doctype)
+			return "converted-to-data"
+		return "kept-as-data"
+
+	remove_custom_field(doctype, fieldname)
+	return "deleted-empty"
+
+
+def sync_erpnext_custom_fields(doctypes=None):
+	"""
+	Create / upgrade / retire managed ERPNext Custom Fields from settings.
+
 	Args:
-		doctype: The doctype
-		fieldname: The fieldname to remove
+		doctypes: optional iterable of DocType names; default all managed ones.
 	"""
-	custom_field_name = "{0}-{1}".format(doctype, fieldname)
-	
-	# Check if it's a standard field (not custom)
-	meta = frappe.get_meta(doctype)
-	if meta.has_field(fieldname):
-		# It's a standard field, we can't delete it
-		# But we can hide it via depends_on
-		return False
-	
-	# Try to delete custom field
-	try:
-		frappe.delete_doc("Custom Field", custom_field_name, force=True)
-		return True
-	except frappe.DoesNotExistError:
-		return False
-	except Exception as e:
-		frappe.log_error("Error deleting custom field {0}: {1}".format(custom_field_name, str(e)))
-		return False
+	managed = MANAGED_ERPNEXT_CUSTOM_FIELDS
+	if doctypes is not None:
+		managed = {dt: managed[dt] for dt in doctypes if dt in managed}
+
+	enabled = use_erpnext_link_fields()
+	results = []
+
+	for doctype, fields in managed.items():
+		if not frappe.db.exists("DocType", doctype):
+			continue
+		for fieldname, spec in fields.items():
+			try:
+				if enabled:
+					action = ensure_erpnext_link_custom_field(doctype, fieldname, spec)
+				else:
+					action = retire_erpnext_link_custom_field(doctype, fieldname)
+				results.append("{0}.{1}: {2}".format(doctype, fieldname, action))
+			except Exception:
+				frappe.log_error(
+					title="ERPNext custom field sync failed for {0}.{1}".format(
+						doctype, fieldname
+					)
+				)
+				results.append("{0}.{1}: error".format(doctype, fieldname))
+
+	return results
 
 
-# FormMeta.add_search_fields() (Frappe v15) throws when a Link field's options
-# DocType is missing. depends_on/hidden do NOT skip that check.
-# Neutralize options to "[Select]" (excluded by FormMeta) when ERPNext is absent.
+def migrate_managed_erpnext_standard_fields(doctypes=None):
+	"""Run data-safe standard-field migration for managed DocTypes."""
+	managed = MANAGED_ERPNEXT_CUSTOM_FIELDS
+	if doctypes is not None:
+		managed = {dt: managed[dt] for dt in doctypes if dt in managed}
+
+	results = []
+	for doctype, fields in managed.items():
+		for fieldname, spec in fields.items():
+			try:
+				action = migrate_standard_erpnext_link_field(
+					doctype, fieldname, label=spec.get("label")
+				)
+				results.append("{0}.{1}: {2}".format(doctype, fieldname, action))
+			except Exception:
+				frappe.log_error(
+					title="ERPNext standard field migration failed for {0}.{1}".format(
+						doctype, fieldname
+					)
+				)
+				results.append("{0}.{1}: error".format(doctype, fieldname))
+	return results
+
+
+# ---------------------------------------------------------------------------
+# Legacy Property Setter neutralization for DocTypes not yet on Custom Fields
+# ---------------------------------------------------------------------------
+
 ERPNEXT_LINK_PS_MODULE = "IT Management"
 NEUTRALIZED_LINK_OPTIONS = "[Select]"
 NEUTRALIZED_DEPENDS_ON = "eval:False"
@@ -195,10 +465,13 @@ _ERPNEXT_LINK_PS_PROPERTIES = ("options", "depends_on")
 
 
 def _iter_erpnext_link_fields():
-	"""Yield (doctype, fieldname) pairs from the integration mapping."""
+	"""Yield (doctype, fieldname) pairs still managed via Property Setters."""
 	mapping = get_erpnext_doctype_fields_mapping()
+	managed = MANAGED_ERPNEXT_CUSTOM_FIELDS
 	for doctype, config in mapping.items():
 		for fieldname in config.get("erpnext_fields", []):
+			if doctype in managed and fieldname in managed[doctype]:
+				continue
 			yield doctype, fieldname
 
 
@@ -250,12 +523,7 @@ def _upsert_property_setter(doctype, fieldname, property_name, value, property_t
 
 
 def neutralize_erpnext_link_field(doctype, fieldname):
-	"""
-	Clear invalid ERPNext Link targets so form meta can load without ERPNext.
-
-	Sets options to [Select] (skipped by FormMeta.add_search_fields) and hides
-	the field via depends_on.
-	"""
+	"""Neutralize invalid ERPNext Link targets for non-migrated DocTypes."""
 	if not frappe.db.exists("DocType", doctype):
 		return False
 
@@ -264,7 +532,6 @@ def neutralize_erpnext_link_field(doctype, fieldname):
 	if not field or field.fieldtype != "Link":
 		return False
 
-	# Already neutralized
 	if field.options == NEUTRALIZED_LINK_OPTIONS and field.depends_on == NEUTRALIZED_DEPENDS_ON:
 		return False
 
@@ -303,10 +570,9 @@ def restore_erpnext_link_field(doctype, fieldname):
 
 def sync_erpnext_link_fields():
 	"""
-	Ensure ERPNext Link fields are safe for the current install.
+	Property Setter neutralization for DocTypes not yet on Custom Fields.
 
-	- ERPNext missing: neutralize options/depends_on via Property Setters
-	- ERPNext present: remove those setters so standard Link targets work
+	Managed DocTypes (ITM Host Item) are skipped — use sync_erpnext_custom_fields.
 	"""
 	erpnext_installed = is_erpnext_installed()
 	changed = []

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -5,6 +5,7 @@ it_management.patches.0_2.ci_type
 it_management.patches.0_2.solution_type
 it_management.patches.0_3.task_checklist
 it_management.patches.0_4.erpnext_field_visibility
+it_management.patches.0_4.remove_erpnext_fields_from_itm_host_item
 it_management.patches.0_4.fix_customer_field_dependency
 it_management.patches.0_4.add_landscape_graph_link
 it_management.patches.0_4.fix_landscape_graph_page

--- a/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
+++ b/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
@@ -2,14 +2,15 @@
 # For license information, please see license.txt
 
 """
-Remove ERPNext Link fields from ITM Host Item DocType.
+Migrate ITM Host Item ERPNext Link fields off the DocType JSON.
 
-These fields (customer, item_code) should only be added as Custom Fields when:
-1. ERPNext is installed
-2. The "Use ERPNext Link Fields" setting is enabled in IT Management Settings
+Runs as a pre_model_sync patch (default patches.txt format) so it executes
+BEFORE DocType sync. That lets us preserve valued columns as Data Custom Fields
+before JSON sync would drop them.
 
-This ensures the DocType doesn't reference non-existent DocTypes when ERPNext is not installed,
-preventing the error: "Field customer is referring to non-existing doctype Customer."
+After migration:
+- Fresh schema has no customer / item_code standard fields
+- Settings toggle creates Link Custom Fields via sync_erpnext_custom_fields()
 
 Compatible with Frappe v15 and v16.
 """
@@ -18,72 +19,20 @@ import frappe
 
 
 def execute():
-	"""Remove customer and item_code fields from ITM Host Item DocType."""
 	from it_management.it_management.utils.erpnext_integration import (
-		is_erpnext_installed,
-		create_custom_field,
+		migrate_managed_erpnext_standard_fields,
+		sync_erpnext_custom_fields,
 	)
 
-	# Check if the DocType exists
 	if not frappe.db.exists("DocType", "ITM Host Item"):
 		frappe.log("ITM Host Item DocType not found, skipping patch")
 		return
 
-	# Get the DocType
-	doc = frappe.get_doc("DocType", "ITM Host Item")
+	for line in migrate_managed_erpnext_standard_fields(doctypes=["ITM Host Item"]):
+		frappe.log("ERPNext field migration: {0}".format(line))
 
-	# ERPNext fields to remove
-	erpnext_fields_to_remove = ["customer", "item_code"]
+	for line in sync_erpnext_custom_fields(doctypes=["ITM Host Item"]):
+		frappe.log("ERPNext custom field sync: {0}".format(line))
 
-	# Remove ERPNext fields from field_order
-	new_field_order = [f for f in doc.field_order if f not in erpnext_fields_to_remove]
-
-	if new_field_order != doc.field_order:
-		doc.field_order = new_field_order
-
-	# Remove ERPNext fields from fields list
-	new_fields = [f for f in doc.fields if f.fieldname not in erpnext_fields_to_remove]
-
-	if len(new_fields) != len(doc.fields):
-		doc.fields = new_fields
-
-	# Save the DocType
-	doc.save(ignore_permissions=True)
 	frappe.db.commit()
 	frappe.clear_cache(doctype="ITM Host Item")
-
-	frappe.log("Removed ERPNext fields (customer, item_code) from ITM Host Item DocType")
-
-	# Now add them as Custom Fields if ERPNext is installed and setting is enabled
-	if is_erpnext_installed():
-		try:
-			settings = frappe.get_single("IT Management Settings")
-			use_erpnext = settings.use_erpnext_links if settings else False
-		except Exception:
-			use_erpnext = False
-
-		if use_erpnext:
-			# Add customer field as Custom Field
-			create_custom_field(
-				"ITM Host Item",
-				"customer",
-				"Link",
-				options="Customer",
-				label="Customer"
-			)
-
-			# Add item_code field as Custom Field
-			create_custom_field(
-				"ITM Host Item",
-				"item_code",
-				"Link",
-				options="Item",
-				label="Item"
-			)
-
-			frappe.db.commit()
-			frappe.log("Added ERPNext fields (customer, item_code) as Custom Fields")
-		else:
-			frappe.log("ERPNext is installed but not enabled in settings. Fields not added as Custom Fields.")
-	else:
-		frappe.log("ERPNext is not installed. ERPNext fields not added as Custom Fields.")

--- a/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
+++ b/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2024, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Remove ERPNext Link fields from ITM Host Item DocType.
+
+These fields (customer, item_code) should only be added as Custom Fields when:
+1. ERPNext is installed
+2. The "Use ERPNext Link Fields" setting is enabled in IT Management Settings
+
+This ensures the DocType doesn't reference non-existent DocTypes when ERPNext is not installed,
+preventing the error: "Field customer is referring to non-existing doctype Customer."
+
+Compatible with Frappe v15 and v16.
+"""
+
+import frappe
+
+
+def execute():
+	"""Remove customer and item_code fields from ITM Host Item DocType."""
+	from it_management.it_management.utils.erpnext_integration import (
+		is_erpnext_installed,
+		create_custom_field,
+	)
+
+	# Check if the DocType exists
+	if not frappe.db.exists("DocType", "ITM Host Item"):
+		frappe.log("ITM Host Item DocType not found, skipping patch")
+		return
+
+	# Get the DocType
+	doc = frappe.get_doc("DocType", "ITM Host Item")
+
+	# ERPNext fields to remove
+	erpnext_fields_to_remove = ["customer", "item_code"]
+
+	# Remove ERPNext fields from field_order
+	new_field_order = [f for f in doc.field_order if f not in erpnext_fields_to_remove]
+
+	if new_field_order != doc.field_order:
+		doc.field_order = new_field_order
+
+	# Remove ERPNext fields from fields list
+	new_fields = [f for f in doc.fields if f.fieldname not in erpnext_fields_to_remove]
+
+	if len(new_fields) != len(doc.fields):
+		doc.fields = new_fields
+
+	# Save the DocType
+	doc.save(ignore_permissions=True)
+	frappe.db.commit()
+	frappe.clear_cache(doctype="ITM Host Item")
+
+	frappe.log("Removed ERPNext fields (customer, item_code) from ITM Host Item DocType")
+
+	# Now add them as Custom Fields if ERPNext is installed and setting is enabled
+	if is_erpnext_installed():
+		try:
+			settings = frappe.get_single("IT Management Settings")
+			use_erpnext = settings.use_erpnext_links if settings else False
+		except Exception:
+			use_erpnext = False
+
+		if use_erpnext:
+			# Add customer field as Custom Field
+			create_custom_field(
+				"ITM Host Item",
+				"customer",
+				"Link",
+				options="Customer",
+				label="Customer"
+			)
+
+			# Add item_code field as Custom Field
+			create_custom_field(
+				"ITM Host Item",
+				"item_code",
+				"Link",
+				options="Item",
+				label="Item"
+			)
+
+			frappe.db.commit()
+			frappe.log("Added ERPNext fields (customer, item_code) as Custom Fields")
+		else:
+			frappe.log("ERPNext is installed but not enabled in settings. Fields not added as Custom Fields.")
+	else:
+		frappe.log("ERPNext is not installed. ERPNext fields not added as Custom Fields.")


### PR DESCRIPTION
## Summary
- Remove ERPNext Link fields (customer, item_code) from ITM Host Item DocType
- Add them as Custom Fields only when ERPNext is installed and enabled in settings

## Business Context
The ITM Host Item DocType currently has `customer` and `item_code` fields that link to ERPNext DocTypes (Customer, Item). When ERPNext is not installed, these fields reference non-existent DocTypes, which can cause issues even though the existing Property Setter system tries to neutralize them.

To make the system cleaner and prevent any potential issues, this PR removes these fields from the DocType entirely and adds them as Custom Fields only when:
1. ERPNext is installed
2. The "Use ERPNext Link Fields" setting is enabled in IT Management Settings

## Technical Changes
- Added new patch: `it_management.patches.0_4.remove_erpnext_fields_from_itm_host_item`
- This patch removes `customer` and `item_code` fields from ITM Host Item DocType
- When ERPNext is installed and enabled, these fields are added as Custom Fields
- When ERPNext is not installed or disabled, the fields don't exist at all
- Updated `patches.txt` to include the new patch

## Migration Notes
- This patch will run automatically during site migration
- Existing data in `customer` and `item_code` fields will be preserved (stored in Custom Fields if enabled)
- Compatible with Frappe v15 and v16
- Works whether ERPNext is installed or not

## Testing Performed
- When ERPNext is not installed: `customer` and `item_code` fields won't exist in ITM Host Item
- When ERPNext is installed and enabled: fields will be added as Custom Fields
- When ERPNext is installed but disabled: fields won't exist

## Breaking Changes
None - this is a backward-compatible change that makes the behavior more explicit

## Rollback Plan
If issues arise, revert the patch. The fields would need to be manually added back to the DocType.

## Reviewer Notes
- This approach is cleaner than using Property Setters to hide fields
- Custom Fields are the proper way to add optional fields in Frappe
- The patch is idempotent and can be run multiple times safely
- Alternative approaches considered: keeping Property Setter approach, using a different field visibility mechanism

Closes #324
