### PR TITLE
fix: migrate all ITM DocType ERPNext Links to settings Custom Fields

### DIFF
--- a/it_management/it_management/doctype/itm_location_room/itm_location_room.json
+++ b/it_management/it_management/doctype/itm_location_room/itm_location_room.json
@@ -14,7 +14,6 @@
   "column_break_6",
   "note",
   "itm_location",
-  "customer",
   "itm_landscape"
  ],
  "fields": [
@@ -32,13 +31,6 @@
    "fieldname": "note",
    "fieldtype": "Small Text",
    "label": "Note"
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Customer",
-   "options": "Customer"
   },
   {
    "fieldname": "itm_floor",
@@ -72,7 +64,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-06 12:12:28.319668",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Location Room",
@@ -106,7 +98,7 @@
  ],
  "quick_entry": 1,
  "row_format": "Dynamic",
- "search_fields": "title,itm_floor,room_number",
+ "search_fields": "title, itm_floor, room_number",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/it_management/it_management/doctype/itm_solution/itm_solution.json
+++ b/it_management/it_management/doctype/itm_solution/itm_solution.json
@@ -13,11 +13,9 @@
   "importance",
   "itm_solution_type",
   "column_break_3",
-  "customer",
   "customer_name",
   "itm_landscape",
   "itm_location",
-  "supplier",
   "section_break_7",
   "description",
   "itm_solution_table",
@@ -53,27 +51,13 @@
    "in_standard_filter": 1
   },
   {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Customer",
-   "options": "Customer"
-  },
-  {
    "bold": 1,
-   "fetch_from": "customer.customer_name",
    "fieldname": "customer_name",
    "fieldtype": "Data",
    "in_global_search": 1,
    "label": "Customer Name",
-   "read_only": 1
-  },
-  {
-   "fieldname": "supplier",
-   "fieldtype": "Link",
-   "label": "Supplier",
-   "options": "Supplier"
+   "read_only": 1,
+   "fetch_from": "customer.customer_name"
   },
   {
    "fieldname": "section_break_7",
@@ -135,7 +119,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-06 12:02:51.377562",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Solution",
@@ -168,7 +152,7 @@
   }
  ],
  "row_format": "Dynamic",
- "search_fields": "customer, customer_name, itm_solution_type",
+ "search_fields": "customer_name, itm_solution_type",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/it_management/it_management/doctype/itm_solution_table/itm_solution_table.json
+++ b/it_management/it_management/doctype/itm_solution_table/itm_solution_table.json
@@ -7,8 +7,7 @@
  "field_order": [
   "note",
   "itm_solution",
-  "status",
-  "customer"
+  "status"
  ],
  "fields": [
   {
@@ -26,13 +25,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Customer",
-   "options": "Customer"
-  },
-  {
    "fieldname": "itm_solution",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -44,7 +36,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-04-06 12:03:18.124429",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Solution Table",

--- a/it_management/it_management/doctype/itm_trip/itm_trip.json
+++ b/it_management/it_management/doctype/itm_trip/itm_trip.json
@@ -9,7 +9,6 @@
   "status",
   "employee",
   "employee_name",
-  "customer",
   "customer_name",
   "destination",
   "date",
@@ -46,20 +45,12 @@
    "read_only": 1
   },
   {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Customer",
-   "options": "Customer",
-   "reqd": 1
-  },
-  {
-   "fetch_from": "customer.customer_name",
    "fieldname": "customer_name",
    "fieldtype": "Data",
    "in_standard_filter": 1,
    "label": "Customer Name",
-   "read_only": 1
+   "read_only": 1,
+   "fetch_from": "customer.customer_name"
   },
   {
    "fieldname": "destination",
@@ -122,7 +113,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-06 11:56:31.694931",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Trip",

--- a/it_management/it_management/doctype/itm_user_account/itm_user_account.json
+++ b/it_management/it_management/doctype/itm_user_account/itm_user_account.json
@@ -10,7 +10,6 @@
  "field_order": [
   "itm_user_account_type",
   "general_section",
-  "customer",
   "customer_name",
   "itm_landscape",
   "contact",
@@ -41,20 +40,12 @@
    "label": "General"
   },
   {
-   "allow_in_quick_entry": 1,
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "in_standard_filter": 1,
-   "label": "Customer",
-   "options": "Customer"
-  },
-  {
    "bold": 1,
-   "fetch_from": "customer.customer_name",
    "fieldname": "customer_name",
    "fieldtype": "Data",
    "label": "Customer Name",
-   "read_only": 1
+   "read_only": 1,
+   "fetch_from": "customer.customer_name"
   },
   {
    "fieldname": "contact",
@@ -187,7 +178,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-06 12:04:34.550368",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM User Account",
@@ -220,7 +211,7 @@
   }
  ],
  "row_format": "Dynamic",
- "search_fields": "description,user_name,customer",
+ "search_fields": "description, user_name, customer_name",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/it_management/it_management/doctype/itm_user_account_type/itm_user_account_type.json
+++ b/it_management/it_management/doctype/itm_user_account_type/itm_user_account_type.json
@@ -7,8 +7,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title",
-  "customer"
+  "title"
  ],
  "fields": [
   {
@@ -16,17 +15,10 @@
    "fieldtype": "Data",
    "label": "Title",
    "unique": 1
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Customer",
-   "options": "Customer"
   }
  ],
  "links": [],
- "modified": "2025-12-17 15:32:01.396274",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM User Account Type",

--- a/it_management/it_management/doctype/itm_user_group/itm_user_group.json
+++ b/it_management/it_management/doctype/itm_user_group/itm_user_group.json
@@ -9,7 +9,6 @@
  "field_order": [
   "title",
   "general_section",
-  "customer",
   "customer_name",
   "itm_landscape",
   "column_break_6",
@@ -31,18 +30,12 @@
    "label": "General"
   },
   {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "label": "Customer",
-   "options": "Customer"
-  },
-  {
    "bold": 1,
-   "fetch_from": "customer.customer_name",
    "fieldname": "customer_name",
    "fieldtype": "Data",
    "label": "Customer Name",
-   "read_only": 1
+   "read_only": 1,
+   "fetch_from": "customer.customer_name"
   },
   {
    "fieldname": "column_break_6",
@@ -86,7 +79,7 @@
   }
  ],
  "links": [],
- "modified": "2026-04-06 12:01:17.477778",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM User Group",

--- a/it_management/it_management/doctype/itm_user_group_table/itm_user_group_table.json
+++ b/it_management/it_management/doctype/itm_user_group_table/itm_user_group_table.json
@@ -6,8 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "note",
-  "itm_user_group",
-  "customer"
+  "itm_user_group"
  ],
  "fields": [
   {
@@ -15,13 +14,6 @@
    "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Note"
-  },
-  {
-   "fieldname": "customer",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Customer",
-   "options": "Customer"
   },
   {
    "fieldname": "itm_user_group",
@@ -33,7 +25,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-04-06 12:01:36.489220",
+ "modified": "2026-07-18 14:20:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM User Group Table",

--- a/it_management/it_management/utils/erpnext_integration.py
+++ b/it_management/it_management/utils/erpnext_integration.py
@@ -170,6 +170,7 @@ MANAGED_ERPNEXT_CUSTOM_FIELDS = {
 			"options": "Customer",
 			"insert_after": "general_section",
 			"in_standard_filter": 1,
+			"allow_in_quick_entry": 1,
 		},
 	},
 	"ITM User Account Type": {
@@ -205,6 +206,7 @@ _CF_SPEC_ATTRS = (
 	"in_standard_filter",
 	"bold",
 	"read_only",
+	"allow_in_quick_entry",
 )
 
 ERPNEXT_CF_MODULE = "IT Management"

--- a/it_management/it_management/utils/erpnext_integration.py
+++ b/it_management/it_management/utils/erpnext_integration.py
@@ -104,14 +104,14 @@ def get_erpnext_doctype_fields_mapping():
 			"itm_fields": [],
 		},
 		"ITM Solution": {
-			"erpnext_fields": ["customer"],
+			"erpnext_fields": ["customer", "supplier"],
 			"itm_fields": [],
 		},
 	}
 
 
 # DocTypes whose ERPNext Links are managed as Custom Fields (not in JSON).
-# Extend this map as more DocTypes are migrated off standard Link fields.
+# All ITM-* DocTypes that previously linked to Customer/Item/Supplier.
 MANAGED_ERPNEXT_CUSTOM_FIELDS = {
 	"ITM Host Item": {
 		"customer": {
@@ -124,8 +124,88 @@ MANAGED_ERPNEXT_CUSTOM_FIELDS = {
 			"options": "Item",
 			"insert_after": "item_section",
 		},
-	}
+	},
+	"ITM Location Room": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "itm_location",
+			"hidden": 1,
+		},
+	},
+	"ITM Solution": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "column_break_3",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+		},
+		"supplier": {
+			"label": "Supplier",
+			"options": "Supplier",
+			"insert_after": "itm_location",
+		},
+	},
+	"ITM Solution Table": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "status",
+			"hidden": 1,
+		},
+	},
+	"ITM Trip": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "employee_name",
+			"reqd": 1,
+			"in_list_view": 1,
+		},
+	},
+	"ITM User Account": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "general_section",
+			"in_standard_filter": 1,
+		},
+	},
+	"ITM User Account Type": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "title",
+			"hidden": 1,
+		},
+	},
+	"ITM User Group": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "general_section",
+		},
+	},
+	"ITM User Group Table": {
+		"customer": {
+			"label": "Customer",
+			"options": "Customer",
+			"insert_after": "itm_user_group",
+			"hidden": 1,
+		},
+	},
 }
+
+# Extra Custom Field attributes copied from the former standard DocFields.
+_CF_SPEC_ATTRS = (
+	"hidden",
+	"reqd",
+	"in_list_view",
+	"in_standard_filter",
+	"bold",
+	"read_only",
+)
 
 ERPNEXT_CF_MODULE = "IT Management"
 
@@ -261,7 +341,7 @@ def _is_standard_docfield(doctype, fieldname):
 	)
 
 
-def migrate_standard_erpnext_link_field(doctype, fieldname, label=None):
+def migrate_standard_erpnext_link_field(doctype, fieldname, label=None, cf_attrs=None):
 	"""
 	Data-safe removal of a standard ERPNext Link field before model sync.
 
@@ -283,6 +363,7 @@ def migrate_standard_erpnext_link_field(doctype, fieldname, label=None):
 		return "absent"
 
 	label = label or fieldname.replace("_", " ").title()
+	cf_attrs = cf_attrs or {}
 	table = _table_name(doctype)
 	tmp_col = "_{0}_mig".format(fieldname)
 	value_count = _nonempty_value_count(doctype, fieldname)
@@ -304,12 +385,17 @@ def migrate_standard_erpnext_link_field(doctype, fieldname, label=None):
 		if get_custom_field(doctype, fieldname):
 			remove_custom_field(doctype, fieldname)
 
+		cf_kwargs = {"module": ERPNEXT_CF_MODULE}
+		for key in _CF_SPEC_ATTRS:
+			if key in cf_attrs and cf_attrs[key] is not None:
+				cf_kwargs[key] = cf_attrs[key]
+
 		create_custom_field(
 			doctype,
 			fieldname,
 			"Data",
 			label=label,
-			module=ERPNEXT_CF_MODULE,
+			**cf_kwargs
 		)
 
 		if frappe.db.has_column(doctype, fieldname) and frappe.db.has_column(doctype, tmp_col):
@@ -325,11 +411,21 @@ def migrate_standard_erpnext_link_field(doctype, fieldname, label=None):
 	return "removed-empty"
 
 
+def _spec_field_attrs(spec):
+	"""Return Custom Field attribute kwargs from a managed-field spec."""
+	attrs = {}
+	for key in _CF_SPEC_ATTRS:
+		if key in spec and spec[key] is not None:
+			attrs[key] = spec[key]
+	return attrs
+
+
 def ensure_erpnext_link_custom_field(doctype, fieldname, spec):
 	"""Ensure a Link Custom Field exists (upgrade Data → Link when enabling)."""
 	options = spec.get("options")
 	label = spec.get("label") or fieldname
 	insert_after = spec.get("insert_after")
+	extra = _spec_field_attrs(spec)
 
 	custom = get_custom_field(doctype, fieldname)
 	if custom:
@@ -346,6 +442,10 @@ def ensure_erpnext_link_custom_field(doctype, fieldname, spec):
 		if insert_after and custom.insert_after != insert_after:
 			custom.insert_after = insert_after
 			changed = True
+		for key, value in extra.items():
+			if custom.get(key) != value:
+				custom.set(key, value)
+				changed = True
 		if changed:
 			custom.save(ignore_permissions=True)
 			frappe.clear_cache(doctype=doctype)
@@ -359,6 +459,7 @@ def ensure_erpnext_link_custom_field(doctype, fieldname, spec):
 	kwargs = {"module": ERPNEXT_CF_MODULE}
 	if insert_after:
 		kwargs["insert_after"] = insert_after
+	kwargs.update(extra)
 
 	created = create_custom_field(
 		doctype,
@@ -441,7 +542,10 @@ def migrate_managed_erpnext_standard_fields(doctypes=None):
 		for fieldname, spec in fields.items():
 			try:
 				action = migrate_standard_erpnext_link_field(
-					doctype, fieldname, label=spec.get("label")
+					doctype,
+					fieldname,
+					label=spec.get("label"),
+					cf_attrs=_spec_field_attrs(spec),
 				)
 				results.append("{0}.{1}: {2}".format(doctype, fieldname, action))
 			except Exception:

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -6,6 +6,7 @@ it_management.patches.0_2.solution_type
 it_management.patches.0_3.task_checklist
 it_management.patches.0_4.erpnext_field_visibility
 it_management.patches.0_4.remove_erpnext_fields_from_itm_host_item
+it_management.patches.0_4.migrate_itm_erpnext_link_fields
 it_management.patches.0_4.fix_customer_field_dependency
 it_management.patches.0_4.add_landscape_graph_link
 it_management.patches.0_4.fix_landscape_graph_page

--- a/it_management/patches/0_4/migrate_itm_erpnext_link_fields.py
+++ b/it_management/patches/0_4/migrate_itm_erpnext_link_fields.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2024, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Migrate all ITM-* DocType ERPNext Link fields to settings-driven Custom Fields.
+
+Covers every ITM DocType that linked to Customer / Item / Supplier (including
+ITM Solution, ITM Trip, ITM User Account, child tables, etc.).
+
+Pre_model_sync (default patches.txt): preserve valued columns as Data Custom
+Fields before DocType JSON sync would drop them, then apply the current
+IT Management Settings toggle.
+
+Compatible with Frappe v15 and v16.
+"""
+
+import frappe
+
+
+def execute():
+	from it_management.it_management.utils.erpnext_integration import (
+		migrate_managed_erpnext_standard_fields,
+		sync_erpnext_custom_fields,
+	)
+
+	for line in migrate_managed_erpnext_standard_fields():
+		frappe.log("ITM ERPNext field migration: {0}".format(line))
+
+	for line in sync_erpnext_custom_fields():
+		frappe.log("ITM ERPNext custom field sync: {0}".format(line))
+
+	frappe.db.commit()

--- a/it_management/patches/0_4/migrate_itm_erpnext_link_fields.py
+++ b/it_management/patches/0_4/migrate_itm_erpnext_link_fields.py
@@ -2,14 +2,17 @@
 # For license information, please see license.txt
 
 """
-Migrate all ITM-* DocType ERPNext Link fields to settings-driven Custom Fields.
+Migrate all remaining ITM-* DocType ERPNext Link fields to Custom Fields.
 
-Covers every ITM DocType that linked to Customer / Item / Supplier (including
-ITM Solution, ITM Trip, ITM User Account, child tables, etc.).
+Companion to remove_erpnext_fields_from_itm_host_item (Host Item + Solution).
+This patch covers every other ITM DocType that linked to Customer / Item /
+Supplier, and is also safe to re-run for Host Item / Solution (idempotent).
 
-Pre_model_sync (default patches.txt): preserve valued columns as Data Custom
-Fields before DocType JSON sync would drop them, then apply the current
-IT Management Settings toggle.
+Needed because sites that already executed the Host-Item-only patch will not
+re-run it after that file was extended to include ITM Solution.
+
+Pre_model_sync: preserve valued columns as Data Custom Fields, then apply
+IT Management Settings via sync_erpnext_custom_fields().
 
 Compatible with Frappe v15 and v16.
 """
@@ -23,6 +26,7 @@ def execute():
 		sync_erpnext_custom_fields,
 	)
 
+	# All managed ITM DocTypes (Host Item, Solution, Trip, User Account, …)
 	for line in migrate_managed_erpnext_standard_fields():
 		frappe.log("ITM ERPNext field migration: {0}".format(line))
 

--- a/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
+++ b/it_management/patches/0_4/remove_erpnext_fields_from_itm_host_item.py
@@ -2,20 +2,27 @@
 # For license information, please see license.txt
 
 """
-Migrate ITM Host Item ERPNext Link fields off the DocType JSON.
+Migrate ERPNext Link fields off ITM Host Item and ITM Solution DocTypes.
 
-Runs as a pre_model_sync patch (default patches.txt format) so it executes
-BEFORE DocType sync. That lets us preserve valued columns as Data Custom Fields
-before JSON sync would drop them.
+Aligned with the Host Item + Solution scope from PR discussions: these fields
+must not ship as standard Links (FormMeta fails without ERPNext). They are
+managed as Custom Fields when ERPNext is installed and
+"Use ERPNext Link Fields" is enabled.
 
-After migration:
-- Fresh schema has no customer / item_code standard fields
-- Settings toggle creates Link Custom Fields via sync_erpnext_custom_fields()
+Data-safe (pre_model_sync):
+- valued Link columns → Data Custom Fields (same fieldname)
+- empty Link columns → removed
+- then sync_erpnext_custom_fields() applies the settings toggle
+
+Further ITM-* DocTypes are covered by migrate_itm_erpnext_link_fields.
 
 Compatible with Frappe v15 and v16.
 """
 
 import frappe
+
+# Same DocTypes/fields as the Host Item + Solution alignment target
+_HOST_ITEM_AND_SOLUTION = ("ITM Host Item", "ITM Solution")
 
 
 def execute():
@@ -24,15 +31,13 @@ def execute():
 		sync_erpnext_custom_fields,
 	)
 
-	if not frappe.db.exists("DocType", "ITM Host Item"):
-		frappe.log("ITM Host Item DocType not found, skipping patch")
-		return
-
-	for line in migrate_managed_erpnext_standard_fields(doctypes=["ITM Host Item"]):
+	for line in migrate_managed_erpnext_standard_fields(doctypes=list(_HOST_ITEM_AND_SOLUTION)):
 		frappe.log("ERPNext field migration: {0}".format(line))
 
-	for line in sync_erpnext_custom_fields(doctypes=["ITM Host Item"]):
+	for line in sync_erpnext_custom_fields(doctypes=list(_HOST_ITEM_AND_SOLUTION)):
 		frappe.log("ERPNext custom field sync: {0}".format(line))
 
 	frappe.db.commit()
-	frappe.clear_cache(doctype="ITM Host Item")
+	for doctype in _HOST_ITEM_AND_SOLUTION:
+		if frappe.db.exists("DocType", doctype):
+			frappe.clear_cache(doctype=doctype)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Aligns with [#326](https://github.com/phamos-eu/it_management/pull/326)’s intent (ITM Host Item **and** ITM Solution) using the data-safe Custom Field approach from #324
- Extends the same pattern to **every ITM-* DocType** that linked to `Customer` / `Item` / `Supplier`
- Removes those Links from DocType JSON; settings toggle creates Link Custom Fields when ERPNext is installed and enabled

## Relationship to #326
#326 rewrites `remove_erpnext_fields_from_itm_host_item` with `DocType.save()` (no JSON changes, data-loss risk, conflicts with develop after #324). **This PR supersedes #326**:
- Same Host Item + Solution scope in `remove_erpnext_fields_from_itm_host_item.py`, but via `migrate_managed_erpnext_standard_fields` / `sync_erpnext_custom_fields`
- Plus JSON cleanup and coverage for remaining ITM DocTypes via `migrate_itm_erpnext_link_fields` (needed for sites that already ran the Host-Item-only patch)

Please close #326 in favor of this PR.

## DocTypes covered
| DocType | Fields |
|---------|--------|
| ITM Host Item | `customer`, `item_code` |
| ITM Solution | `customer`, `supplier` |
| ITM Solution Table | `customer` (hidden) |
| ITM Trip | `customer` |
| ITM User Account | `customer` |
| ITM User Account Type | `customer` (hidden) |
| ITM User Group | `customer` |
| ITM User Group Table | `customer` (hidden) |
| ITM Location Room | `customer` (hidden) |

## Technical Changes
- Expanded `MANAGED_ERPNEXT_CUSTOM_FIELDS`
- `remove_erpnext_fields_from_itm_host_item` → Host Item + Solution (data-safe)
- New `migrate_itm_erpnext_link_fields` → all managed ITM DocTypes (idempotent)
- Valued Links preserved as Data Custom Fields; empty Links removed
- Non-ITM DocTypes still use Property Setter neutralization from #323

## Testing
1. `bench migrate` without ERPNext → open ITM Solution / Trip / User Account
2. Existing `customer` values survive migrate
3. Enable “Use ERPNext Link Fields” with ERPNext → Link Custom Fields appear
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae363637-b7ab-4ea7-9577-da51fe4f9e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae363637-b7ab-4ea7-9577-da51fe4f9e2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

