### PR TITLE
fix: ITM Host Item status spelling Obsolet → Obsolete

### DIFF
--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -28,11 +28,12 @@
    "unique": 1
   },
   {
+   "default": "Implementing",
    "fieldname": "status",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "\nImplementing\nRunning\nIssue\nStorage\nObsolete"
+   "options": "Implementing\nRunning\nIssue\nStorage\nObsolete"
   },
   {
    "fieldname": "serial_number",

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -32,7 +32,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "\nImplementing\nRunning\nIssue\nStorage\nObsolet"
+   "options": "\nImplementing\nRunning\nIssue\nStorage\nObsolete"
   },
   {
    "fieldname": "serial_number",

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -10,3 +10,4 @@ it_management.patches.0_4.migrate_itm_erpnext_link_fields
 it_management.patches.0_4.fix_customer_field_dependency
 it_management.patches.0_4.add_landscape_graph_link
 it_management.patches.0_4.fix_landscape_graph_page
+it_management.patches.0_4.rename_itm_host_item_obsolet_status

--- a/it_management/patches/0_4/rename_itm_host_item_obsolet_status.py
+++ b/it_management/patches/0_4/rename_itm_host_item_obsolet_status.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Rename ITM Host Item status value Obsolet → Obsolete.
+
+Keeps the existing status set (Implementing, Running, Issue, Storage, Obsolete)
+and only corrects the English spelling on ITM Host Item. Existing records with
+status "Obsolet" are updated so they remain valid after the Select options change.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Host Item"):
+		return
+
+	if not frappe.db.has_column("ITM Host Item", "status"):
+		return
+
+	count = frappe.db.count("ITM Host Item", {"status": "Obsolet"})
+	if not count:
+		frappe.log("ITM Host Item: no Obsolet status values to rename")
+		return
+
+	frappe.db.sql(
+		"""
+		UPDATE `tabITM Host Item`
+		SET `status` = 'Obsolete'
+		WHERE `status` = 'Obsolet'
+		"""
+	)
+	frappe.log(
+		"ITM Host Item: renamed status Obsolet → Obsolete on {0} record(s)".format(count)
+	)
+	frappe.db.commit()

--- a/it_management/patches/0_4/rename_itm_host_item_obsolet_status.py
+++ b/it_management/patches/0_4/rename_itm_host_item_obsolet_status.py
@@ -2,11 +2,12 @@
 # For license information, please see license.txt
 
 """
-Rename ITM Host Item status value Obsolet → Obsolete.
+Normalize ITM Host Item status values after Select options cleanup.
 
-Keeps the existing status set (Implementing, Running, Issue, Storage, Obsolete)
-and only corrects the English spelling on ITM Host Item. Existing records with
-status "Obsolet" are updated so they remain valid after the Select options change.
+- Renames Obsolet → Obsolete (spelling fix)
+- Sets blank/NULL status → Implementing (empty option removed; default is Implementing)
+
+Keeps the status set: Implementing, Running, Issue, Storage, Obsolete.
 """
 
 import frappe
@@ -19,19 +20,44 @@ def execute():
 	if not frappe.db.has_column("ITM Host Item", "status"):
 		return
 
-	count = frappe.db.count("ITM Host Item", {"status": "Obsolet"})
-	if not count:
+	obsolet_count = frappe.db.count("ITM Host Item", {"status": "Obsolet"})
+	if obsolet_count:
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Host Item`
+			SET `status` = 'Obsolete'
+			WHERE `status` = 'Obsolet'
+			"""
+		)
+		frappe.log(
+			"ITM Host Item: renamed status Obsolet → Obsolete on {0} record(s)".format(
+				obsolet_count
+			)
+		)
+	else:
 		frappe.log("ITM Host Item: no Obsolet status values to rename")
-		return
 
-	frappe.db.sql(
+	# Empty string or NULL (blank Select option removed)
+	blank_count = frappe.db.sql(
 		"""
-		UPDATE `tabITM Host Item`
-		SET `status` = 'Obsolete'
-		WHERE `status` = 'Obsolet'
+		SELECT COUNT(*) FROM `tabITM Host Item`
+		WHERE IFNULL(`status`, '') = ''
 		"""
-	)
-	frappe.log(
-		"ITM Host Item: renamed status Obsolet → Obsolete on {0} record(s)".format(count)
-	)
+	)[0][0]
+	if blank_count:
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Host Item`
+			SET `status` = 'Implementing'
+			WHERE IFNULL(`status`, '') = ''
+			"""
+		)
+		frappe.log(
+			"ITM Host Item: set blank status → Implementing on {0} record(s)".format(
+				blank_count
+			)
+		)
+	else:
+		frappe.log("ITM Host Item: no blank status values to set")
+
 	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Corrects the ITM Host Item status option spelling from `Obsolet` to `Obsolete`.
- Removes the blank Select option and sets the default to `Implementing`.
- Status set remains: Implementing, Running, Issue, Storage, Obsolete.
- Migrate patch updates existing records:
  - `Obsolet` → `Obsolete`
  - blank/NULL status → `Implementing`

Scoped first step toward [#291](https://github.com/phamos-eu/it_management/issues/291). Other DocTypes are unchanged for now.

## Test plan

- [ ] On a site with ITM Host Items at status `Obsolet`, run `bench migrate` and confirm those rows become `Obsolete`.
- [ ] On a site with blank/NULL status, confirm those rows become `Implementing` after migrate.
- [ ] Confirm the status dropdown has no empty option, defaults to `Implementing` on new Host Items, and shows `Obsolete` (not `Obsolet`).
- [ ] Confirm other statuses are untouched.
- [ ] Re-run migrate and confirm the patch is idempotent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

