### PR TITLE
feat: Physical/Virtual deployment on ITM Host Item

### DIFF
--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -10,7 +10,11 @@
  "field_order": [
   "title",
   "status",
+  "deployment",
   "serial_number",
+  "hosting_section",
+  "hosted_by_software_instance",
+  "hosted_on",
   "customer_section",
   "itm_customer",
   "item_section",
@@ -36,9 +40,45 @@
    "options": "Implementing\nRunning\nIssue\nStorage\nObsolete"
   },
   {
+   "default": "Physical",
+   "fieldname": "deployment",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Deployment",
+   "options": "Physical\nVirtual",
+   "reqd": 1
+  },
+  {
    "fieldname": "serial_number",
    "fieldtype": "Data",
    "label": "Serial Number"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.deployment=='Virtual'",
+   "fieldname": "hosting_section",
+   "fieldtype": "Section Break",
+   "label": "Hosting"
+  },
+  {
+   "depends_on": "eval:doc.deployment=='Virtual'",
+   "description": "Software Instance that provides hosting for this virtual host (e.g. Hyper-V, ESXi, Proxmox).",
+   "fieldname": "hosted_by_software_instance",
+   "fieldtype": "Link",
+   "label": "Hosted by Software Instance",
+   "mandatory_depends_on": "eval:doc.deployment=='Virtual'",
+   "options": "ITM Software Instance"
+  },
+  {
+   "depends_on": "eval:doc.deployment=='Virtual'",
+   "description": "Parent host derived from the hosting Software Instance.",
+   "fetch_from": "hosted_by_software_instance.itm_host_item",
+   "fieldname": "hosted_on",
+   "fieldtype": "Link",
+   "label": "Hosted On",
+   "options": "ITM Host Item",
+   "read_only": 1
   },
   {
    "fieldname": "customer_section",
@@ -94,9 +134,13 @@
   {
    "link_doctype": "ITM Software Instance",
    "link_fieldname": "itm_host_item"
+  },
+  {
+   "link_doctype": "ITM Host Item",
+   "link_fieldname": "hosted_on"
   }
  ],
- "modified": "2026-07-18 14:00:00.000000",
+ "modified": "2026-07-18 21:10:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Host Item",

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.py
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.py
@@ -60,6 +60,8 @@ class ITMHostItem(Document):
 						title=_("Missing Doctype"),
 					)
 
+		self._validate_deployment_hosting()
+
 		if self.get("itm_host_item_solution_table"):
 			solutions = [
 				row.itm_solution
@@ -71,3 +73,36 @@ class ITMHostItem(Document):
 					_("A solution can only be linked once to a host item"),
 					title=_("Duplicate Solution"),
 				)
+
+	def _validate_deployment_hosting(self):
+		"""Physical hosts clear hosting links; Virtual hosts require a Software Instance."""
+		if not self.deployment:
+			self.deployment = "Physical"
+
+		if self.deployment == "Physical":
+			self.hosted_by_software_instance = None
+			self.hosted_on = None
+			return
+
+		if self.deployment != "Virtual":
+			return
+
+		if not self.hosted_by_software_instance:
+			frappe.throw(
+				_("Virtual hosts must be linked to a hosting Software Instance."),
+				title=_("Missing Hosting Software Instance"),
+			)
+
+		# Keep hosted_on in sync even if fetch_from did not run (e.g. API/import)
+		parent_host = frappe.db.get_value(
+			"ITM Software Instance",
+			self.hosted_by_software_instance,
+			"itm_host_item",
+		)
+		self.hosted_on = parent_host
+
+		if self.hosted_on and self.hosted_on == self.name:
+			frappe.throw(
+				_("A host item cannot be hosted on itself."),
+				title=_("Invalid Hosting"),
+			)

--- a/it_management/it_management/doctype/itm_software_instance/itm_software_instance.json
+++ b/it_management/it_management/doctype/itm_software_instance/itm_software_instance.json
@@ -51,9 +51,13 @@
   {
    "link_doctype": "ITM User Account",
    "link_fieldname": "itm_software_instance"
+  },
+  {
+   "link_doctype": "ITM Host Item",
+   "link_fieldname": "hosted_by_software_instance"
   }
  ],
- "modified": "2026-04-06 12:04:54.303954",
+ "modified": "2026-07-18 21:10:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Software Instance",

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -11,3 +11,4 @@ it_management.patches.0_4.fix_customer_field_dependency
 it_management.patches.0_4.add_landscape_graph_link
 it_management.patches.0_4.fix_landscape_graph_page
 it_management.patches.0_4.rename_itm_host_item_obsolet_status
+it_management.patches.0_4.set_itm_host_item_deployment_physical

--- a/it_management/patches/0_4/set_itm_host_item_deployment_physical.py
+++ b/it_management/patches/0_4/set_itm_host_item_deployment_physical.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Set deployment = Physical on existing ITM Host Items after the field is introduced.
+
+New hosts default to Physical; this patch fills blank/NULL values for older rows.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Host Item"):
+		return
+
+	if not frappe.db.has_column("ITM Host Item", "deployment"):
+		return
+
+	count = frappe.db.sql(
+		"""
+		SELECT COUNT(*) FROM `tabITM Host Item`
+		WHERE IFNULL(`deployment`, '') = ''
+		"""
+	)[0][0]
+	if not count:
+		frappe.log("ITM Host Item: no blank deployment values to set")
+		return
+
+	frappe.db.sql(
+		"""
+		UPDATE `tabITM Host Item`
+		SET `deployment` = 'Physical'
+		WHERE IFNULL(`deployment`, '') = ''
+		"""
+	)
+	frappe.log(
+		"ITM Host Item: set deployment → Physical on {0} record(s)".format(count)
+	)
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds deployment modeling for ITM Host Item, with virtual hosts tied to the **Software Instance** that provides hosting (not only the parent host).

- **Deployment**: `Physical` | `Virtual` (default `Physical`, required)
- **Hosted by Software Instance**: required when Virtual (e.g. Hyper-V, ESXi, Proxmox)
- **Hosted On**: read-only, fetched from `hosted_by_software_instance.itm_host_item` (also synced in `validate` for API/import)
- Physical clears hosting links
- Connections: guest Host Items on parent host (`hosted_on`) and on Software Instance (`hosted_by_software_instance`)
- Migrate patch sets blank `deployment` to `Physical` on existing rows

Public/external cloud as a third deployment value is intentionally deferred.

## Test plan

- [ ] New ITM Host Item defaults to Deployment = Physical; Hosting section hidden
- [ ] Set Deployment = Virtual → Hosting section shown; saving without Software Instance fails
- [ ] Link a Software Instance that has a Host Item → Hosted On fills with that host
- [ ] Switch back to Physical → hosting fields cleared on save
- [ ] Parent host Connections show guest Host Items; Software Instance Connections show hosted Host Items
- [ ] `bench migrate` on an existing site sets blank deployment to Physical

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

