### PR TITLE
feat: Lifecycle Status and Health Status for ITM Host, SI, Solution

### DIFF
--- a/it_management/api.py
+++ b/it_management/api.py
@@ -37,35 +37,54 @@ def get_landscape_graph_data(landscape=None, solutions=None):
 	# Fetch all ITM Host Items (with or without Solution)
 	host_items = frappe.get_all(
 		"ITM Host Item",
-		fields=["name", "title", "status", "itm_solution", "itm_landscape"],
+		fields=["name", "title", "lifecycle_status", "itm_landscape"],
 		filters=filters,
 		order_by="title"
 	)
 
+	# Solution membership lives on ITM Host Item Solution Table (M2M)
+	host_solutions = {}
+	if host_items:
+		host_names = [host["name"] for host in host_items]
+		for row in frappe.get_all(
+			"ITM Host Item Solution Table",
+			filters={
+				"parent": ["in", host_names],
+				"parenttype": "ITM Host Item",
+			},
+			fields=["parent", "itm_solution"],
+		):
+			if not row.itm_solution:
+				continue
+			host_solutions.setdefault(row.parent, []).append(row.itm_solution)
+
 	# Filter by solutions if specified
 	if selected_solutions:
+		selected = set(selected_solutions)
 		host_items = [
-			host for host in host_items 
-			if host.get("itm_solution") in selected_solutions
+			host
+			for host in host_items
+			if selected.intersection(host_solutions.get(host["name"], []))
 		]
 
 	# Build nodes list
 	nodes = []
 	for host in host_items:
+		solutions = host_solutions.get(host["name"], [])
 		node = {
 			"key": host["name"],
 			"text": host["title"] or host["name"],
-			"status": host.get("status", ""),
-			"solution": host.get("itm_solution", ""),
-			"landscape": host.get("itm_landscape", "")
+			"status": host.get("lifecycle_status", ""),
+			"solution": solutions[0] if solutions else "",
+			"solutions": solutions,
+			"landscape": host.get("itm_landscape", ""),
 		}
 		nodes.append(node)
 
-	# Build groups (Solutions) - only for hosts that have a solution
+	# Build groups (Solutions) from M2M membership
 	solution_groups = {}
 	for host in host_items:
-		solution_name = host.get("itm_solution")
-		if solution_name:
+		for solution_name in host_solutions.get(host["name"], []):
 			if solution_name not in solution_groups:
 				solution_groups[solution_name] = {
 					"members": []
@@ -73,7 +92,8 @@ def get_landscape_graph_data(landscape=None, solutions=None):
 			# Use the solution name as the key, but sanitize it for GoJS
 			safe_key = f"SOL-{solution_name.replace(' ', '-').replace('_', '-')}"
 			solution_groups[solution_name]["key"] = safe_key
-			solution_groups[solution_name]["members"].append(host["name"])
+			if host["name"] not in solution_groups[solution_name]["members"]:
+				solution_groups[solution_name]["members"].append(host["name"])
 
 	# Convert groups dict to list
 	groups = []

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.json
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.json
@@ -9,7 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
-  "status",
+  "lifecycle_status",
+  "health_status",
   "serial_number",
   "customer_section",
   "itm_customer",
@@ -29,11 +30,23 @@
   },
   {
    "default": "Implementing",
-   "fieldname": "status",
+   "fieldname": "lifecycle_status",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Status",
-   "options": "Implementing\nRunning\nIssue\nStorage\nObsolete"
+   "in_standard_filter": 1,
+   "label": "Lifecycle Status",
+   "options": "Implementing\nRunning\nStorage\nObsolete",
+   "reqd": 1
+  },
+  {
+   "default": "Unknown",
+   "fieldname": "health_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Health Status",
+   "options": "Healthy\nWarning\nCritical\nUnknown",
+   "reqd": 1
   },
   {
    "fieldname": "serial_number",
@@ -96,7 +109,7 @@
    "link_fieldname": "itm_host_item"
   }
  ],
- "modified": "2026-07-18 14:00:00.000000",
+ "modified": "2026-07-18 22:00:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Host Item",

--- a/it_management/it_management/doctype/itm_host_item/itm_host_item.py
+++ b/it_management/it_management/doctype/itm_host_item/itm_host_item.py
@@ -60,6 +60,11 @@ class ITMHostItem(Document):
 						title=_("Missing Doctype"),
 					)
 
+		if not self.lifecycle_status:
+			self.lifecycle_status = "Implementing"
+		if not self.health_status:
+			self.health_status = "Unknown"
+
 		if self.get("itm_host_item_solution_table"):
 			solutions = [
 				row.itm_solution
@@ -71,3 +76,43 @@ class ITMHostItem(Document):
 					_("A solution can only be linked once to a host item"),
 					title=_("Duplicate Solution"),
 				)
+
+	def on_update(self):
+		from it_management.it_management.utils.status import (
+			cascade_host_lifecycle_to_software_instances,
+			solutions_linked_to_host,
+			update_solution_health,
+		)
+
+		if self.has_value_changed("lifecycle_status"):
+			cascade_host_lifecycle_to_software_instances(self.name, self.lifecycle_status)
+
+		before = self.get_doc_before_save()
+		before_solutions = {
+			row.itm_solution
+			for row in (before.get("itm_host_item_solution_table") if before else []) or []
+			if row.itm_solution
+		}
+		after_solutions = {
+			row.itm_solution
+			for row in self.get("itm_host_item_solution_table") or []
+			if row.itm_solution
+		}
+		membership_changed = before_solutions != after_solutions
+
+		if (
+			self.has_value_changed("lifecycle_status")
+			or self.has_value_changed("health_status")
+			or membership_changed
+		):
+			for solution in solutions_linked_to_host(self):
+				update_solution_health(solution)
+
+	def after_insert(self):
+		from it_management.it_management.utils.status import (
+			solutions_linked_to_host,
+			update_solution_health,
+		)
+
+		for solution in solutions_linked_to_host(self):
+			update_solution_health(solution)

--- a/it_management/it_management/doctype/itm_software_instance/itm_software_instance.json
+++ b/it_management/it_management/doctype/itm_software_instance/itm_software_instance.json
@@ -9,6 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
+  "lifecycle_status",
+  "health_status",
   "itm_host_item",
   "itm_landscape",
   "itm_software",
@@ -20,6 +22,26 @@
    "fieldtype": "Data",
    "label": "Title",
    "unique": 1
+  },
+  {
+   "default": "Implementing",
+   "fieldname": "lifecycle_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Lifecycle Status",
+   "options": "Implementing\nRunning\nStorage\nUninstalled\nObsolete",
+   "reqd": 1
+  },
+  {
+   "default": "Unknown",
+   "fieldname": "health_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Health Status",
+   "options": "Healthy\nWarning\nCritical\nUnknown",
+   "reqd": 1
   },
   {
    "fieldname": "itm_host_item",
@@ -53,7 +75,7 @@
    "link_fieldname": "itm_software_instance"
   }
  ],
- "modified": "2026-04-06 12:04:54.303954",
+ "modified": "2026-07-18 22:00:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Software Instance",

--- a/it_management/it_management/doctype/itm_software_instance/itm_software_instance.py
+++ b/it_management/it_management/doctype/itm_software_instance/itm_software_instance.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2024, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
+
 class ITMSoftwareInstance(Document):
-	pass
+	def validate(self):
+		if not self.lifecycle_status:
+			self.lifecycle_status = "Implementing"
+		if not self.health_status:
+			self.health_status = "Unknown"

--- a/it_management/it_management/doctype/itm_solution/itm_solution.json
+++ b/it_management/it_management/doctype/itm_solution/itm_solution.json
@@ -9,7 +9,8 @@
  "engine": "InnoDB",
  "field_order": [
   "name1",
-  "status",
+  "lifecycle_status",
+  "health_status",
   "importance",
   "itm_solution_type",
   "column_break_3",
@@ -32,11 +33,26 @@
    "unique": 1
   },
   {
-   "fieldname": "status",
+   "default": "Implementing",
+   "fieldname": "lifecycle_status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Status",
-   "options": "Implementing\nRunning\nIssue\nStorage\nObsolet"
+   "label": "Lifecycle Status",
+   "options": "Implementing\nRunning\nStorage\nObsolete",
+   "reqd": 1
+  },
+  {
+   "default": "Unknown",
+   "description": "Derived from linked Host Items with Lifecycle Status Running (worst wins).",
+   "fieldname": "health_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Health Status",
+   "options": "Healthy\nWarning\nCritical\nUnknown",
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "fieldname": "importance",
@@ -119,7 +135,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-18 14:20:00.000000",
+ "modified": "2026-07-18 22:00:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Solution",

--- a/it_management/it_management/doctype/itm_solution/itm_solution.py
+++ b/it_management/it_management/doctype/itm_solution/itm_solution.py
@@ -1,9 +1,17 @@
 # Copyright (c) 2025, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class ITMSolution(Document):
-	pass
+	def validate(self):
+		from it_management.it_management.utils.status import compute_solution_health
+
+		if not self.lifecycle_status:
+			self.lifecycle_status = "Implementing"
+
+		# Health is derived from linked Running Host Items
+		solution_name = self.name or self.get("name1")
+		self.health_status = compute_solution_health(solution_name)

--- a/it_management/it_management/doctype/itm_solution_table/itm_solution_table.json
+++ b/it_management/it_management/doctype/itm_solution_table/itm_solution_table.json
@@ -17,11 +17,11 @@
    "label": "Note"
   },
   {
-   "fetch_from": "solution.status",
+   "fetch_from": "itm_solution.lifecycle_status",
    "fieldname": "status",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Status",
+   "label": "Lifecycle Status",
    "read_only": 1
   },
   {

--- a/it_management/it_management/utils/status.py
+++ b/it_management/it_management/utils/status.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""Lifecycle and Health status helpers for ITM DocTypes."""
+
+from __future__ import unicode_literals
+
+import frappe
+
+LIFECYCLE_OPTIONS = ("Implementing", "Running", "Storage", "Obsolete")
+LIFECYCLE_OPTIONS_SOFTWARE_INSTANCE = LIFECYCLE_OPTIONS + ("Uninstalled",)
+HEALTH_OPTIONS = ("Healthy", "Warning", "Critical", "Unknown")
+
+HEALTH_RANK = {
+	"Critical": 3,
+	"Warning": 2,
+	"Unknown": 1,
+	"Healthy": 0,
+}
+
+# Host lifecycle values that cascade to Software Instances
+CASCADE_LIFECYCLE = {
+	"Storage": "Storage",
+	"Obsolete": "Obsolete",
+}
+
+# Software Instance lifecycle values that must not be overwritten by cascade
+CASCADE_SKIP_SI = frozenset(("Obsolete", "Uninstalled"))
+
+
+def map_legacy_status(old_status):
+	"""Map legacy blended status → (lifecycle_status, health_status)."""
+	if not old_status:
+		return "Implementing", "Unknown"
+
+	if old_status == "Issue":
+		return "Running", "Critical"
+
+	if old_status in ("Obsolet", "Obsolete"):
+		return "Obsolete", "Unknown"
+
+	if old_status in LIFECYCLE_OPTIONS:
+		return old_status, "Unknown"
+
+	return "Implementing", "Unknown"
+
+
+def worst_health(health_values):
+	"""Return the worst health among values; Unknown if empty."""
+	if not health_values:
+		return "Unknown"
+
+	worst = "Healthy"
+	worst_rank = -1
+	for value in health_values:
+		rank = HEALTH_RANK.get(value, HEALTH_RANK["Unknown"])
+		if rank > worst_rank:
+			worst = value if value in HEALTH_RANK else "Unknown"
+			worst_rank = rank
+	return worst
+
+
+def compute_solution_health(solution_name):
+	"""
+	Derive Solution health from linked Host Items with Lifecycle Running.
+
+	Worst wins: Critical > Warning > Unknown > Healthy.
+	No Running hosts → Unknown.
+	"""
+	if not solution_name:
+		return "Unknown"
+
+	rows = frappe.db.sql(
+		"""
+		SELECT h.health_status
+		FROM `tabITM Host Item` h
+		INNER JOIN `tabITM Host Item Solution Table` t
+			ON t.parent = h.name
+			AND t.parenttype = 'ITM Host Item'
+		WHERE t.itm_solution = %s
+			AND h.lifecycle_status = 'Running'
+		""",
+		solution_name,
+		as_dict=True,
+	)
+	if not rows:
+		return "Unknown"
+
+	return worst_health([row.get("health_status") or "Unknown" for row in rows])
+
+
+def update_solution_health(solution_name, update_modified=False):
+	"""Set ITM Solution.health_status from linked Running hosts."""
+	if not solution_name or not frappe.db.exists("ITM Solution", solution_name):
+		return
+
+	if not frappe.db.has_column("ITM Solution", "health_status"):
+		return
+
+	new_health = compute_solution_health(solution_name)
+	current = frappe.db.get_value("ITM Solution", solution_name, "health_status")
+	if current == new_health:
+		return
+
+	frappe.db.set_value(
+		"ITM Solution",
+		solution_name,
+		"health_status",
+		new_health,
+		update_modified=update_modified,
+	)
+
+
+def cascade_host_lifecycle_to_software_instances(host_name, lifecycle_status):
+	"""
+	Cascade host Storage/Obsolete to linked Software Instances.
+
+	Skips instances already Obsolete or Uninstalled.
+	"""
+	target = CASCADE_LIFECYCLE.get(lifecycle_status)
+	if not target or not host_name:
+		return
+
+	if not frappe.db.has_column("ITM Software Instance", "lifecycle_status"):
+		return
+
+	instances = frappe.get_all(
+		"ITM Software Instance",
+		filters={"itm_host_item": host_name},
+		fields=["name", "lifecycle_status"],
+	)
+	for row in instances:
+		if row.lifecycle_status in CASCADE_SKIP_SI:
+			continue
+		if row.lifecycle_status == target:
+			continue
+		frappe.db.set_value(
+			"ITM Software Instance",
+			row.name,
+			"lifecycle_status",
+			target,
+			update_modified=False,
+		)
+
+
+def solutions_linked_to_host(host_doc):
+	"""Return solution names linked on a Host Item (current and previous save)."""
+	solutions = set()
+	for row in host_doc.get("itm_host_item_solution_table") or []:
+		if row.itm_solution:
+			solutions.add(row.itm_solution)
+
+	before = host_doc.get_doc_before_save()
+	if before:
+		for row in before.get("itm_host_item_solution_table") or []:
+			if row.itm_solution:
+				solutions.add(row.itm_solution)
+
+	return solutions

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -11,3 +11,4 @@ it_management.patches.0_4.fix_customer_field_dependency
 it_management.patches.0_4.add_landscape_graph_link
 it_management.patches.0_4.fix_landscape_graph_page
 it_management.patches.0_4.rename_itm_host_item_obsolet_status
+it_management.patches.0_4.migrate_itm_lifecycle_health_status

--- a/it_management/patches/0_4/migrate_itm_lifecycle_health_status.py
+++ b/it_management/patches/0_4/migrate_itm_lifecycle_health_status.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Replace blended ITM status with lifecycle_status + health_status.
+
+ITM Host Item / ITM Solution:
+- Copy legacy status → lifecycle_status / health_status
+- Issue → lifecycle Running, health Critical
+- Obsolet → lifecycle Obsolete, health Unknown
+- Drop orphaned status column when present
+
+ITM Software Instance:
+- Fill blank lifecycle_status / health_status with defaults
+
+Then refresh ITM Solution health from Running host members.
+"""
+
+import frappe
+
+from it_management.it_management.utils.status import (
+	map_legacy_status,
+	update_solution_health,
+)
+
+
+def execute():
+	_migrate_legacy_status_doctype("ITM Host Item")
+	_migrate_legacy_status_doctype("ITM Solution")
+	_ensure_software_instance_defaults()
+	_refresh_all_solution_health()
+	frappe.db.commit()
+
+
+def _migrate_legacy_status_doctype(doctype):
+	if not frappe.db.exists("DocType", doctype):
+		return
+
+	if not frappe.db.has_column(doctype, "lifecycle_status"):
+		return
+
+	if frappe.db.has_column(doctype, "status"):
+		rows = frappe.db.sql(
+			"""
+			SELECT `name`, `status`
+			FROM `tab{doctype}`
+			""".format(doctype=doctype),
+			as_dict=True,
+		)
+		for row in rows:
+			lifecycle, health = map_legacy_status(row.get("status"))
+			values = {"lifecycle_status": lifecycle}
+			if frappe.db.has_column(doctype, "health_status"):
+				values["health_status"] = health
+			frappe.db.set_value(doctype, row.name, values, update_modified=False)
+
+		frappe.db.sql(
+			"ALTER TABLE `tab{doctype}` DROP COLUMN `status`".format(doctype=doctype)
+		)
+		frappe.log(
+			"{0}: migrated status → lifecycle_status/health_status ({1} row(s))".format(
+				doctype, len(rows)
+			)
+		)
+	else:
+		# Fresh column set: ensure defaults on blank values
+		_fill_blank_lifecycle_health(doctype)
+		frappe.log("{0}: no legacy status column; defaults applied if needed".format(doctype))
+
+
+def _fill_blank_lifecycle_health(doctype):
+	if frappe.db.has_column(doctype, "lifecycle_status"):
+		frappe.db.sql(
+			"""
+			UPDATE `tab{doctype}`
+			SET `lifecycle_status` = 'Implementing'
+			WHERE IFNULL(`lifecycle_status`, '') = ''
+			""".format(doctype=doctype)
+		)
+	if frappe.db.has_column(doctype, "health_status"):
+		frappe.db.sql(
+			"""
+			UPDATE `tab{doctype}`
+			SET `health_status` = 'Unknown'
+			WHERE IFNULL(`health_status`, '') = ''
+			""".format(doctype=doctype)
+		)
+
+
+def _ensure_software_instance_defaults():
+	doctype = "ITM Software Instance"
+	if not frappe.db.exists("DocType", doctype):
+		return
+	if not frappe.db.has_column(doctype, "lifecycle_status"):
+		return
+	_fill_blank_lifecycle_health(doctype)
+	frappe.log("ITM Software Instance: applied lifecycle/health defaults where blank")
+
+
+def _refresh_all_solution_health():
+	if not frappe.db.exists("DocType", "ITM Solution"):
+		return
+	if not frappe.db.has_column("ITM Solution", "health_status"):
+		return
+
+	for name in frappe.get_all("ITM Solution", pluck="name"):
+		update_solution_health(name, update_modified=False)
+
+	frappe.log("ITM Solution: refreshed derived health_status")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the agreed Lifecycle / Health split for inventory elements (#291 direction):

| Field | Options |
|-------|---------|
| **Lifecycle Status** | Implementing · Running · Storage · Obsolete (+ **Uninstalled** on Software Instance) |
| **Health Status** | Healthy · Warning · Critical · Unknown |

**Defaults:** Lifecycle `Implementing`, Health `Unknown`

### DocTypes
- **ITM Host Item** / **ITM Solution**: replace blended `status` with `lifecycle_status` + `health_status`
- **ITM Software Instance**: add both fields (no prior status)

Keeps **Physical/Virtual deployment** from #329 (hosting fields + validation).

### Behaviour
- **Host → SI cascade:** Lifecycle `Storage` / `Obsolete` updates linked Software Instances; skips SIs already `Obsolete` or `Uninstalled`
- **Solution Health:** read-only, derived from linked Host Items with Lifecycle **Running** (worst wins: Critical > Warning > Unknown > Healthy); no Running hosts → `Unknown`
- Recalculates when a linked host’s lifecycle/health changes or solution membership changes

### Migration
Patch maps legacy values:
- `Issue` → Lifecycle `Running`, Health `Critical`
- `Obsolet` / `Obsolete` → Lifecycle `Obsolete`, Health `Unknown`
- other lifecycle values → Health `Unknown`
- drops orphaned `status` columns after copy

Also updates landscape graph API for `lifecycle_status` and Host↔Solution M2M membership.

### Deferred (as agreed)
- Primary/secondary host roles
- ITM Issue → Health
- External/Cloud deployment
- User Account status split

## Test plan

- [ ] `bench migrate` on a site with Host/Solution `status` values including Issue and Obsolet; confirm lifecycle/health mapping and no `status` field on forms
- [ ] New Host / SI / Solution default to Implementing + Unknown
- [ ] Virtual deployment + hosting fields still work after merge with #329
- [ ] Set Host Lifecycle to Storage → linked SIs become Storage (not already Obsolete/Uninstalled)
- [ ] Set Host Lifecycle to Obsolete → linked SIs become Obsolete
- [ ] Set a Running host’s Health to Critical → linked Solution Health becomes Critical
- [ ] No Running hosts on a Solution → Health Unknown
- [ ] Solution Lifecycle remains manually editable; Health is read-only
- [ ] Landscape graph still loads host nodes (status from lifecycle)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

