### PR TITLE
feat: ITM Location Site/Building/Floor/Room hierarchy

### DIFF
--- a/it_management/it_management/doctype/itm_location/itm_location.js
+++ b/it_management/it_management/doctype/itm_location/itm_location.js
@@ -2,7 +2,62 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('ITM Location', {
-	// refresh: function(frm) {
+	setup(frm) {
+		frm.set_query('itm_parent_location', () => {
+			const expected = {
+				Building: 'Site',
+				Floor: 'Building',
+				Room: 'Floor',
+			}[frm.doc.location_type];
 
-	// }
+			if (!expected) {
+				return {};
+			}
+
+			return {
+				filters: {
+					location_type: expected,
+					disabled: 0,
+				},
+			};
+		});
+	},
+
+	refresh(frm) {
+		frm.trigger('toggle_location_fields');
+	},
+
+	location_type(frm) {
+		frm.trigger('toggle_location_fields');
+		if (frm.doc.location_type === 'Site') {
+			frm.set_value('itm_parent_location', null);
+		}
+	},
+
+	itm_parent_location(frm) {
+		if (frm.doc.location_type === 'Site' || !frm.doc.itm_parent_location) {
+			return;
+		}
+		frappe.db.get_value(
+			'ITM Location',
+			frm.doc.itm_parent_location,
+			'itm_landscape',
+			(r) => {
+				if (r) {
+					frm.set_value('itm_landscape', r.itm_landscape || null);
+				}
+			}
+		);
+	},
+
+	toggle_location_fields(frm) {
+		const is_site = frm.doc.location_type === 'Site';
+		const show_address =
+			frm.doc.location_type === 'Site' || frm.doc.location_type === 'Building';
+
+		frm.set_df_property('itm_landscape', 'read_only', is_site ? 0 : 1);
+		frm.set_df_property('itm_location_address', 'hidden', show_address ? 0 : 1);
+		frm.set_df_property('itm_parent_location', 'hidden', is_site ? 1 : 0);
+		frm.set_df_property('itm_parent_location', 'reqd', is_site ? 0 : 1);
+	},
 });

--- a/it_management/it_management/doctype/itm_location/itm_location.json
+++ b/it_management/it_management/doctype/itm_location/itm_location.json
@@ -9,15 +9,69 @@
  "engine": "InnoDB",
  "field_order": [
   "itm_location_name",
+  "location_type",
+  "itm_landscape",
   "itm_location_address",
+  "itm_parent_location",
   "is_group",
+  "disabled",
   "lft",
   "rgt",
-  "itm_old_parent",
-  "itm_parent_location",
-  "disabled"
+  "itm_old_parent"
  ],
  "fields": [
+  {
+   "fieldname": "itm_location_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Location Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "default": "Site",
+   "fieldname": "location_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Location Type",
+   "options": "Site\nBuilding\nFloor\nRoom",
+   "reqd": 1
+  },
+  {
+   "description": "Set on Site only; inherited by Building, Floor, and Room.",
+   "fieldname": "itm_landscape",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Landscape",
+   "options": "ITM Landscape"
+  },
+  {
+   "depends_on": "eval:doc.location_type=='Site' || doc.location_type=='Building'",
+   "fieldname": "itm_location_address",
+   "fieldtype": "Link",
+   "label": "Location Address",
+   "options": "Address"
+  },
+  {
+   "depends_on": "eval:doc.location_type!='Site'",
+   "description": "Required for Building (Site), Floor (Building), and Room (Floor).",
+   "fieldname": "itm_parent_location",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Parent Location",
+   "mandatory_depends_on": "eval:doc.location_type!='Site'",
+   "options": "ITM Location"
+  },
+  {
+   "default": "1",
+   "description": "Set automatically: groups for Site/Building/Floor; leaf for Room.",
+   "fieldname": "is_group",
+   "fieldtype": "Check",
+   "label": "Is Location Group",
+   "read_only": 1
+  },
   {
    "default": "0",
    "fieldname": "disabled",
@@ -41,36 +95,10 @@
    "read_only": 1
   },
   {
-   "default": "0",
-   "fieldname": "is_group",
-   "fieldtype": "Check",
-   "label": "Is Location Group"
-  },
-  {
-   "fieldname": "itm_location_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Location Name",
-   "reqd": 1,
-   "unique": 1
-  },
-  {
-   "fieldname": "itm_location_address",
-   "fieldtype": "Link",
-   "label": "Location Address",
-   "options": "Address"
-  },
-  {
    "fieldname": "itm_old_parent",
    "fieldtype": "Link",
    "hidden": 1,
    "label": "Old Parent",
-   "options": "ITM Location"
-  },
-  {
-   "fieldname": "itm_parent_location",
-   "fieldtype": "Link",
-   "label": "Parent Location",
    "options": "ITM Location"
   }
  ],
@@ -82,7 +110,7 @@
    "link_fieldname": "itm_location"
   }
  ],
- "modified": "2026-04-06 12:19:24.082572",
+ "modified": "2026-07-18 22:30:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Location",
@@ -99,6 +127,18 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Support Team",
    "share": 1,
    "write": 1
   }

--- a/it_management/it_management/doctype/itm_location/itm_location.py
+++ b/it_management/it_management/doctype/itm_location/itm_location.py
@@ -1,8 +1,110 @@
 # Copyright (c) 2024, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.utils.nestedset import NestedSet
 
+# Child type → required parent type
+PARENT_TYPE = {
+	"Building": "Site",
+	"Floor": "Building",
+	"Room": "Floor",
+}
+
+GROUP_TYPES = frozenset(("Site", "Building", "Floor"))
+
+
 class ITMLocation(NestedSet):
-	pass
+	nsm_parent_field = "itm_parent_location"
+
+	def validate(self):
+		self._normalize_location_type()
+		self._apply_group_flag()
+		self._validate_hierarchy()
+		self._apply_address_rules()
+		self._apply_landscape_rules()
+
+	def on_update(self):
+		super().on_update()
+		self._cascade_landscape_to_descendants()
+
+	def _normalize_location_type(self):
+		if not self.location_type:
+			self.location_type = "Site"
+
+	def _apply_group_flag(self):
+		# Site / Building / Floor are groups; Room is a leaf
+		self.is_group = 1 if self.location_type in GROUP_TYPES else 0
+
+	def _validate_hierarchy(self):
+		if self.location_type == "Site":
+			if self.itm_parent_location:
+				frappe.throw(
+					_("A Site cannot have a parent location."),
+					title=_("Invalid Hierarchy"),
+				)
+			return
+
+		expected_parent_type = PARENT_TYPE.get(self.location_type)
+		if not self.itm_parent_location:
+			frappe.throw(
+				_("{0} must have a parent {1}.").format(
+					_(self.location_type), _(expected_parent_type)
+				),
+				title=_("Missing Parent Location"),
+			)
+
+		if self.itm_parent_location == self.name:
+			frappe.throw(
+				_("A location cannot be its own parent."),
+				title=_("Invalid Hierarchy"),
+			)
+
+		parent_type = frappe.db.get_value(
+			"ITM Location", self.itm_parent_location, "location_type"
+		)
+		if parent_type != expected_parent_type:
+			frappe.throw(
+				_("{0} must be placed under a {1} (got {2}).").format(
+					_(self.location_type),
+					_(expected_parent_type),
+					_(parent_type or _("none")),
+				),
+				title=_("Invalid Hierarchy"),
+			)
+
+	def _apply_address_rules(self):
+		# Address only on Site and Building
+		if self.location_type not in ("Site", "Building"):
+			self.itm_location_address = None
+
+	def _apply_landscape_rules(self):
+		"""Landscape is editable on Site only; children inherit from parent."""
+		if self.location_type == "Site":
+			return
+
+		parent_landscape = frappe.db.get_value(
+			"ITM Location", self.itm_parent_location, "itm_landscape"
+		)
+		self.itm_landscape = parent_landscape
+
+	def _cascade_landscape_to_descendants(self):
+		"""When a Site landscape changes, push it down the whole subtree."""
+		if self.location_type != "Site":
+			return
+
+		if not self.has_value_changed("itm_landscape"):
+			return
+
+		if self.lft is None or self.rgt is None:
+			return
+
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Location`
+			SET `itm_landscape` = %s
+			WHERE `lft` > %s AND `rgt` < %s
+			""",
+			(self.itm_landscape, self.lft, self.rgt),
+		)

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -13,3 +13,4 @@ it_management.patches.0_4.fix_landscape_graph_page
 it_management.patches.0_4.rename_itm_host_item_obsolet_status
 it_management.patches.0_4.set_itm_host_item_deployment_physical
 it_management.patches.0_4.migrate_itm_lifecycle_health_status
+it_management.patches.0_4.set_itm_location_type_site

--- a/it_management/patches/0_4/set_itm_location_type_site.py
+++ b/it_management/patches/0_4/set_itm_location_type_site.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Default location_type / is_group on existing ITM Location rows.
+
+Existing locations become Site (group) so the new hierarchy can be built under them.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Location"):
+		return
+
+	if not frappe.db.has_column("ITM Location", "location_type"):
+		return
+
+	frappe.db.sql(
+		"""
+		UPDATE `tabITM Location`
+		SET `location_type` = 'Site'
+		WHERE IFNULL(`location_type`, '') = ''
+		"""
+	)
+
+	if frappe.db.has_column("ITM Location", "is_group"):
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Location`
+			SET `is_group` = 1
+			WHERE `location_type` IN ('Site', 'Building', 'Floor')
+			"""
+		)
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Location`
+			SET `is_group` = 0
+			WHERE `location_type` = 'Room'
+			"""
+		)
+
+	frappe.log("ITM Location: applied location_type/is_group defaults")
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends **ITM Location** into a strict physical hierarchy (prep for ITM networking DocTypes; no Socket/Jack yet).

| Location Type | Parent | Group | Address | Landscape |
|---------------|--------|-------|---------|-----------|
| **Site** | none | yes | yes | editable |
| **Building** | Site | yes | yes | inherited (read-only) |
| **Floor** | Building | yes | hidden | inherited (read-only) |
| **Room** | Floor | no (leaf) | hidden | inherited (read-only) |

### Behaviour
- Hierarchy validated on save
- Parent link query filtered to the expected parent type
- Changing Site Landscape cascades to all descendants
- `is_group` set automatically from type
- Existing locations default to **Site** via migrate patch
- **ITM Floor** / **ITM Location Room** left unchanged for now

### Next
ITM networking DocTypes (LAN, Subnet, IP, NIC, Host Domain) linking to this tree.

## Test plan

- [ ] Create Site with Landscape + Address
- [ ] Create Building under Site → Landscape inherited, Address allowed
- [ ] Create Floor under Building → no Address; Landscape read-only/inherited
- [ ] Create Room under Floor → `is_group` unchecked
- [ ] Reject invalid parents (e.g. Room under Site)
- [ ] Reject Site with a parent
- [ ] Change Site Landscape → Building/Floor/Room update
- [ ] `bench migrate` sets blank `location_type` to Site on existing rows

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

