### PR TITLE
fix: Cytoscape.js failed to load on IT Landscape Graph

### DIFF
--- a/it_management/it_management/page/it_landscape_graph/it_landscape_graph.js
+++ b/it_management/it_management/page/it_landscape_graph/it_landscape_graph.js
@@ -12,8 +12,9 @@ frappe.pages["it-landscape-graph"].on_page_load = function (wrapper) {
 		<div class="it-landscape-graph-mount"></div>
 	`);
 
+	// Load app JS/CSS only. Cytoscape is resolved via ensure_cytoscape()
+	// because its UMD build does not set window.cytoscape under RequireJS.
 	const assets = [
-		"/assets/it_management/js/lib/cytoscape.min.js",
 		"/assets/it_management/js/it_landscape_graph.js",
 		"/assets/it_management/css/it_landscape_graph.css",
 	];

--- a/it_management/public/js/it_landscape_graph.js
+++ b/it_management/public/js/it_landscape_graph.js
@@ -6,6 +6,8 @@ frappe.provide("it_management.landscape_graph");
 (function () {
 	"use strict";
 
+	const CYTOSCAPE_SRC = "/assets/it_management/js/lib/cytoscape.min.js";
+
 	const HEALTH_COLORS = {
 		Healthy: "#2e7d32",
 		Warning: "#ef6c00",
@@ -18,6 +20,58 @@ frappe.provide("it_management.landscape_graph");
 		Running: "#2e7d32",
 		Storage: "#9e9e9e",
 		Obsolete: "#546e7a",
+	};
+
+	/**
+	 * Cytoscape's UMD build calls define() when RequireJS is present (Frappe Desk),
+	 * which skips setting window.cytoscape. Load via a classic script tag with AMD
+	 * temporarily disabled so the browser-global export runs.
+	 */
+	it_management.landscape_graph.ensure_cytoscape = function () {
+		if (typeof window.cytoscape === "function") {
+			return Promise.resolve(window.cytoscape);
+		}
+
+		if (it_management.landscape_graph._cytoscape_loading) {
+			return it_management.landscape_graph._cytoscape_loading;
+		}
+
+		it_management.landscape_graph._cytoscape_loading = new Promise(
+			(resolve, reject) => {
+				const previous_define = window.define;
+				const restore_define = () => {
+					if (previous_define !== undefined) {
+						window.define = previous_define;
+					}
+				};
+
+				// Force the UMD browser branch: (global).cytoscape = factory()
+				if (typeof window.define === "function" && window.define.amd) {
+					window.define = undefined;
+				}
+
+				const script = document.createElement("script");
+				script.src = CYTOSCAPE_SRC;
+				script.async = true;
+				script.onload = () => {
+					restore_define();
+					if (typeof window.cytoscape === "function") {
+						resolve(window.cytoscape);
+					} else {
+						reject(new Error("Cytoscape loaded but global was not set"));
+					}
+				};
+				script.onerror = () => {
+					restore_define();
+					reject(new Error("Failed to fetch " + CYTOSCAPE_SRC));
+				};
+				document.head.appendChild(script);
+			}
+		).finally(() => {
+			it_management.landscape_graph._cytoscape_loading = null;
+		});
+
+		return it_management.landscape_graph._cytoscape_loading;
 	};
 
 	function escapeHtml(value) {
@@ -48,18 +102,23 @@ frappe.provide("it_management.landscape_graph");
 		}
 
 		init() {
-			if (typeof cytoscape !== "function") {
-				frappe.msgprint({
-					title: __("Missing library"),
-					message: __("Cytoscape.js failed to load."),
-					indicator: "red",
+			return it_management.landscape_graph
+				.ensure_cytoscape()
+				.then(() => {
+					this.render_layout();
+					this.bind_events();
+					return this.load_filter_options().then(() => this.load_graph_data());
+				})
+				.catch((err) => {
+					console.error(err);
+					frappe.msgprint({
+						title: __("Missing library"),
+						message: __(
+							"Cytoscape.js failed to load. Hard-refresh the page or run bench clear-cache / bench build if assets are missing."
+						),
+						indicator: "red",
+					});
 				});
-				return;
-			}
-
-			this.render_layout();
-			this.bind_events();
-			this.load_filter_options().then(() => this.load_graph_data());
 		}
 
 		render_layout() {
@@ -471,6 +530,6 @@ frappe.provide("it_management.landscape_graph");
 		const graph = new it_management.landscape_graph.ITLandscapeGraph({
 			wrapper: root,
 		});
-		graph.init();
+		return graph.init();
 	};
 })();

--- a/it_management/www/it_landscape_graph.html
+++ b/it_management/www/it_landscape_graph.html
@@ -7,7 +7,6 @@
 <div class="it-landscape-graph-mount"></div>
 
 <link rel="stylesheet" href="/assets/it_management/css/it_landscape_graph.css">
-<script src="/assets/it_management/js/lib/cytoscape.min.js"></script>
 <script src="/assets/it_management/js/it_landscape_graph.js"></script>
 <script>
 	document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes `Cytoscape.js failed to load` when opening the IT Landscape Graph on Desk.

## Cause
Frappe Desk loads scripts under RequireJS. Cytoscape’s UMD build detects AMD and calls `define()` instead of setting `window.cytoscape`, so the graph init check failed.

## Fix
Load Cytoscape via a classic `<script>` tag with `define` temporarily unset so the browser-global export runs, then restore AMD.

## Test plan
- [ ] Open `/app/it-landscape-graph` — graph renders, no missing-library dialog
- [ ] Hard-refresh once after deploy (`bench clear-cache` if needed)
- [ ] Confirm hosts/solutions still load and interactions work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20df9175-6033-4497-aed1-e724176b7280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20df9175-6033-4497-aed1-e724176b7280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

