### PR TITLE
fix: add Networking section to IT Management workspace

### DIFF
--- a/it_management/it_management/doctype/itm_landscape/itm_landscape.json
+++ b/it_management/it_management/doctype/itm_landscape/itm_landscape.json
@@ -30,9 +30,41 @@
   {
    "link_doctype": "ITM Host Item",
    "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Location",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Local Area Network",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Subnet",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM IP Address",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Network Interface Controller",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Socket",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Host Domain",
+   "link_fieldname": "itm_landscape"
+  },
+  {
+   "link_doctype": "ITM Solution",
+   "link_fieldname": "itm_landscape"
   }
  ],
- "modified": "2024-01-30 10:25:19.464775",
+ "modified": "2026-07-18 23:55:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Landscape",

--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,7 +1,7 @@
 {
  "app": "it_management",
  "charts": [],
- "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\",\"col\":12}},{\"id\":\"pferI51Txs\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}}]",
+ "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\",\"col\":12}},{\"id\":\"pferI51Txs\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}},{\"id\":\"itmNetCard1\",\"type\":\"card\",\"data\":{\"card_name\":\"Network\",\"col\":4}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -122,7 +122,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-18 23:05:00.000000",
+ "modified": "2026-07-18 23:45:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",

--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,7 +1,7 @@
 {
  "app": "it_management",
  "charts": [],
- "content": "[{\"id\": \"EkdyV3N5Ie\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">IT Management</span>\", \"col\": 12}}, {\"id\": \"rwNPVL-p3-\", \"type\": \"paragraph\", \"data\": {\"text\": \"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\", \"col\": 12}}, {\"id\": \"lVIHnh6pht\", \"type\": \"paragraph\", \"data\": {\"text\": \"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\", \"col\": 12}}, {\"id\": \"itmCfgHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"pferI51Txs\", \"type\": \"card\", \"data\": {\"card_name\": \"Configuration\", \"col\": 4}}, {\"id\": \"itmNetHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"itmNetPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Manage local area networks, subnets, IP addresses, network interfaces, wall sockets, and host domains for each ITM Landscape.\", \"col\": 12}}, {\"id\": \"itmNetCard1\", \"type\": \"card\", \"data\": {\"card_name\": \"Networking\", \"col\": 4}}]",
+ "content": "[{\"id\": \"EkdyV3N5Ie\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">IT Management</span>\", \"col\": 12}}, {\"id\": \"rwNPVL-p3-\", \"type\": \"paragraph\", \"data\": {\"text\": \"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\", \"col\": 12}}, {\"id\": \"lVIHnh6pht\", \"type\": \"paragraph\", \"data\": {\"text\": \"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\", \"col\": 12}}, {\"id\": \"itmCfgHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"pferI51Txs\", \"type\": \"card\", \"data\": {\"card_name\": \"Configuration\", \"col\": 4}}, {\"id\": \"itmNetHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"itmNetPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Networking for each ITM Landscape: locations, LANs, subnets, IP addresses, host NICs, wall sockets, and host domains.\", \"col\": 12}}, {\"id\": \"itmNetCard1\", \"type\": \"card\", \"data\": {\"card_name\": \"Networking\", \"col\": 6}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -14,115 +14,145 @@
  "label": "IT Management",
  "links": [
   {
+   "type": "Card Break",
+   "label": "Configuration",
+   "link_type": "DocType",
+   "link_count": 3,
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Configuration",
-   "link_count": 3,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
+   "onboard": 0
   },
   {
-   "hidden": 0,
-   "is_query_report": 0,
+   "type": "Link",
    "label": "ITM Landscape",
-   "link_count": 0,
    "link_to": "ITM Landscape",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM Host Item",
-   "link_count": 0,
    "link_to": "ITM Host Item",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "IT Management Settings",
-   "link_count": 0,
    "link_to": "IT Management Settings",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Networking",
-   "link_count": 6,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "ITM Local Area Network",
    "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Card Break",
+   "label": "Networking",
+   "link_type": "DocType",
+   "link_count": 9,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Landscape",
+   "link_to": "ITM Landscape",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Location",
+   "link_to": "ITM Location",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Host Item",
+   "link_to": "ITM Host Item",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Local Area Network",
    "link_to": "ITM Local Area Network",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM Subnet",
-   "link_count": 0,
    "link_to": "ITM Subnet",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM IP Address",
-   "link_count": 0,
    "link_to": "ITM IP Address",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM Network Interface Controller",
-   "link_count": 0,
    "link_to": "ITM Network Interface Controller",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM Socket",
-   "link_count": 0,
    "link_to": "ITM Socket",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
    "label": "ITM Host Domain",
-   "link_count": 0,
    "link_to": "ITM Host Domain",
    "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
   }
  ],
- "modified": "2026-07-18 23:50:00.000000",
+ "modified": "2026-07-18 23:55:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",

--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,7 +1,7 @@
 {
  "app": "it_management",
  "charts": [],
- "content": "[{\"id\":\"EkdyV3N5Ie\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">IT Management</span>\",\"col\":12}},{\"id\":\"rwNPVL-p3-\",\"type\":\"paragraph\",\"data\":{\"text\":\"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\",\"col\":12}},{\"id\":\"lVIHnh6pht\",\"type\":\"paragraph\",\"data\":{\"text\":\"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\",\"col\":12}},{\"id\":\"pferI51Txs\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}},{\"id\":\"itmNetCard1\",\"type\":\"card\",\"data\":{\"card_name\":\"Network\",\"col\":4}}]",
+ "content": "[{\"id\": \"EkdyV3N5Ie\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">IT Management</span>\", \"col\": 12}}, {\"id\": \"rwNPVL-p3-\", \"type\": \"paragraph\", \"data\": {\"text\": \"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\", \"col\": 12}}, {\"id\": \"lVIHnh6pht\", \"type\": \"paragraph\", \"data\": {\"text\": \"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\", \"col\": 12}}, {\"id\": \"itmCfgHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"pferI51Txs\", \"type\": \"card\", \"data\": {\"card_name\": \"Configuration\", \"col\": 4}}, {\"id\": \"itmNetHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"itmNetPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Manage local area networks, subnets, IP addresses, network interfaces, wall sockets, and host domains for each ITM Landscape.\", \"col\": 12}}, {\"id\": \"itmNetCard1\", \"type\": \"card\", \"data\": {\"card_name\": \"Networking\", \"col\": 4}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -55,7 +55,7 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Network",
+   "label": "Networking",
    "link_count": 6,
    "link_type": "DocType",
    "onboard": 0,
@@ -122,7 +122,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-18 23:45:00.000000",
+ "modified": "2026-07-18 23:50:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -14,3 +14,4 @@ it_management.patches.0_4.rename_itm_host_item_obsolet_status
 it_management.patches.0_4.set_itm_host_item_deployment_physical
 it_management.patches.0_4.migrate_itm_lifecycle_health_status
 it_management.patches.0_4.set_itm_location_type_site
+it_management.patches.0_4.reload_itm_workspace_network_card

--- a/it_management/patches/0_4/reload_itm_workspace_network_card.py
+++ b/it_management/patches/0_4/reload_itm_workspace_network_card.py
@@ -17,6 +17,9 @@ WORKSPACE = "IT Management"
 CARD_LABEL = "Networking"
 
 NETWORK_LINKS = [
+	"ITM Landscape",
+	"ITM Location",
+	"ITM Host Item",
 	"ITM Local Area Network",
 	"ITM Subnet",
 	"ITM IP Address",
@@ -36,8 +39,8 @@ NETWORKING_SECTION_BLOCKS = [
 		"type": "paragraph",
 		"data": {
 			"text": (
-				"Manage local area networks, subnets, IP addresses, network "
-				"interfaces, wall sockets, and host domains for each ITM Landscape."
+				"Networking for each ITM Landscape: locations, LANs, subnets, "
+				"IP addresses, host NICs, wall sockets, and host domains."
 			),
 			"col": 12,
 		},

--- a/it_management/patches/0_4/reload_itm_workspace_network_card.py
+++ b/it_management/patches/0_4/reload_itm_workspace_network_card.py
@@ -2,10 +2,10 @@
 # For license information, please see license.txt
 
 """
-Ensure the IT Management workspace shows the Network card.
+Ensure the IT Management workspace shows a Networking section.
 
-The networking DocTypes were added with Card Break links, but the workspace
-`content` JSON only rendered the Configuration card, so Network stayed hidden.
+Adds a Networking header, short description, and card with the ITM
+networking DocTypes (LAN, Subnet, IP, NIC, Socket, Host Domain).
 """
 
 import json
@@ -14,6 +14,7 @@ import frappe
 
 
 WORKSPACE = "IT Management"
+CARD_LABEL = "Networking"
 
 NETWORK_LINKS = [
 	"ITM Local Area Network",
@@ -22,6 +23,30 @@ NETWORK_LINKS = [
 	"ITM Network Interface Controller",
 	"ITM Socket",
 	"ITM Host Domain",
+]
+
+NETWORKING_SECTION_BLOCKS = [
+	{
+		"id": "itmNetHdr1",
+		"type": "header",
+		"data": {"text": '<span class="h5">Networking</span>', "col": 12},
+	},
+	{
+		"id": "itmNetPara1",
+		"type": "paragraph",
+		"data": {
+			"text": (
+				"Manage local area networks, subnets, IP addresses, network "
+				"interfaces, wall sockets, and host domains for each ITM Landscape."
+			),
+			"col": 12,
+		},
+	},
+	{
+		"id": "itmNetCard1",
+		"type": "card",
+		"data": {"card_name": CARD_LABEL, "col": 4},
+	},
 ]
 
 
@@ -35,17 +60,18 @@ def execute():
 		return
 
 	doc = frappe.get_doc("Workspace", WORKSPACE)
-	_ensure_network_card_break(doc)
+	_ensure_networking_card_break(doc)
 	_ensure_network_links(doc)
-	_ensure_network_card_in_content(doc)
+	_ensure_networking_section_in_content(doc)
 	doc.save(ignore_permissions=True)
 	frappe.clear_cache()
-	frappe.log("IT Management workspace: Network card ensured")
+	frappe.log("IT Management workspace: Networking section ensured")
 
 
-def _ensure_network_card_break(doc):
+def _ensure_networking_card_break(doc):
 	for row in doc.links or []:
-		if row.type == "Card Break" and row.label == "Network":
+		if row.type == "Card Break" and row.label in ("Network", "Networking"):
+			row.label = CARD_LABEL
 			row.link_count = len(NETWORK_LINKS)
 			return
 
@@ -53,7 +79,7 @@ def _ensure_network_card_break(doc):
 		"links",
 		{
 			"type": "Card Break",
-			"label": "Network",
+			"label": CARD_LABEL,
 			"link_type": "DocType",
 			"link_count": len(NETWORK_LINKS),
 			"hidden": 0,
@@ -82,25 +108,43 @@ def _ensure_network_links(doc):
 		)
 
 
-def _ensure_network_card_in_content(doc):
+def _ensure_networking_section_in_content(doc):
 	try:
 		blocks = json.loads(doc.content or "[]")
 	except (TypeError, ValueError):
 		blocks = []
 
-	has_network_card = any(
-		block.get("type") == "card"
-		and (block.get("data") or {}).get("card_name") == "Network"
+	# Drop older Network-only card so we can insert the full section once
+	blocks = [
+		block
 		for block in blocks
-	)
-	if has_network_card:
-		return
+		if not (
+			block.get("type") == "card"
+			and (block.get("data") or {}).get("card_name") in ("Network", "Networking")
+		)
+		and block.get("id") not in ("itmNetHdr1", "itmNetPara1", "itmNetCard1")
+	]
 
-	blocks.append(
-		{
-			"id": "itmNetCard1",
-			"type": "card",
-			"data": {"card_name": "Network", "col": 4},
-		}
-	)
+	# Ensure Configuration has a section header for consistency
+	has_config_header = any(block.get("id") == "itmCfgHdr1" for block in blocks)
+	if not has_config_header:
+		for idx, block in enumerate(blocks):
+			if (
+				block.get("type") == "card"
+				and (block.get("data") or {}).get("card_name") == "Configuration"
+			):
+				blocks.insert(
+					idx,
+					{
+						"id": "itmCfgHdr1",
+						"type": "header",
+						"data": {
+							"text": '<span class="h5">Configuration</span>',
+							"col": 12,
+						},
+					},
+				)
+				break
+
+	blocks.extend(NETWORKING_SECTION_BLOCKS)
 	doc.content = json.dumps(blocks)

--- a/it_management/patches/0_4/reload_itm_workspace_network_card.py
+++ b/it_management/patches/0_4/reload_itm_workspace_network_card.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Ensure the IT Management workspace shows the Network card.
+
+The networking DocTypes were added with Card Break links, but the workspace
+`content` JSON only rendered the Configuration card, so Network stayed hidden.
+"""
+
+import json
+
+import frappe
+
+
+WORKSPACE = "IT Management"
+
+NETWORK_LINKS = [
+	"ITM Local Area Network",
+	"ITM Subnet",
+	"ITM IP Address",
+	"ITM Network Interface Controller",
+	"ITM Socket",
+	"ITM Host Domain",
+]
+
+
+def execute():
+	try:
+		frappe.reload_doc("it_management", "workspace", "it_management", force=True)
+	except Exception:
+		frappe.log("Could not reload workspace doc from files; updating DB row")
+
+	if not frappe.db.exists("Workspace", WORKSPACE):
+		return
+
+	doc = frappe.get_doc("Workspace", WORKSPACE)
+	_ensure_network_card_break(doc)
+	_ensure_network_links(doc)
+	_ensure_network_card_in_content(doc)
+	doc.save(ignore_permissions=True)
+	frappe.clear_cache()
+	frappe.log("IT Management workspace: Network card ensured")
+
+
+def _ensure_network_card_break(doc):
+	for row in doc.links or []:
+		if row.type == "Card Break" and row.label == "Network":
+			row.link_count = len(NETWORK_LINKS)
+			return
+
+	doc.append(
+		"links",
+		{
+			"type": "Card Break",
+			"label": "Network",
+			"link_type": "DocType",
+			"link_count": len(NETWORK_LINKS),
+			"hidden": 0,
+		},
+	)
+
+
+def _ensure_network_links(doc):
+	existing = {
+		row.link_to
+		for row in (doc.links or [])
+		if row.type == "Link" and row.link_to
+	}
+	for name in NETWORK_LINKS:
+		if name in existing:
+			continue
+		doc.append(
+			"links",
+			{
+				"type": "Link",
+				"label": name,
+				"link_type": "DocType",
+				"link_to": name,
+				"hidden": 0,
+			},
+		)
+
+
+def _ensure_network_card_in_content(doc):
+	try:
+		blocks = json.loads(doc.content or "[]")
+	except (TypeError, ValueError):
+		blocks = []
+
+	has_network_card = any(
+		block.get("type") == "card"
+		and (block.get("data") or {}).get("card_name") == "Network"
+		for block in blocks
+	)
+	if has_network_card:
+		return
+
+	blocks.append(
+		{
+			"id": "itmNetCard1",
+			"type": "card",
+			"data": {"card_name": "Network", "col": 4},
+		}
+	)
+	doc.content = json.dumps(blocks)

--- a/it_management/workspace_sidebar/it_management.json
+++ b/it_management/workspace_sidebar/it_management.json
@@ -45,6 +45,18 @@
   {
    "child": 0,
    "collapsible": 1,
+   "icon": "map-pin",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "ITM Location",
+   "link_to": "ITM Location",
+   "link_type": "DocType",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
    "icon": "settings",
    "indent": 0,
    "keep_closed": 0,
@@ -127,7 +139,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-18 23:05:00.000000",
+ "modified": "2026-07-18 23:55:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated **Networking** section on the IT Management workspace and links all related DocTypes:

**Networking card**
- ITM Landscape  
- ITM Location  
- ITM Host Item  
- ITM Local Area Network  
- ITM Subnet  
- ITM IP Address  
- ITM Network Interface Controller  
- ITM Socket  
- ITM Host Domain  

Also:
- Section header + short description above the card  
- ITM Location added to the sidebar  
- ITM Landscape **Connections** expanded to the same networking DocTypes (+ Solution)  
- Migrate patch updates existing site workspaces  

## Test plan

- [ ] `bench migrate` and hard-refresh Desk  
- [ ] IT Management workspace shows **Networking** section with all nine links  
- [ ] Each link opens the correct DocType  
- [ ] ITM Landscape Connections lists Host Item, Location, LAN, Subnet, IP, NIC, Socket, Host Domain, Solution  
- [ ] Sidebar includes ITM Location and the network DocTypes  

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

