### PR TITLE
feat: Map View for DocTypes with Address links

### DIFF
--- a/it_management/hooks.py
+++ b/it_management/hooks.py
@@ -31,7 +31,10 @@ add_to_apps_screen = [
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/it_management/css/it_management.css"
-app_include_js = ["/assets/it_management/js/itm_utils.js"]
+app_include_js = [
+	"/assets/it_management/js/itm_utils.js",
+	"/assets/it_management/js/map_view.js",
+]
 
 # include js, css files in header of web template
 # web_include_css = "/assets/it_management/css/it_management.css"
@@ -42,16 +45,17 @@ page_js = {"it-landscape-graph": "public/js/it_landscape_graph.js"}
 
 # include js in doctype views
 doctype_js = {
-    "Communication" : "public/js/communication.js",
-    "Issue" : "public/js/issue.js",
-    "Task" : "public/js/task.js",
-    "Project" : "public/js/project.js",
-    "Sales Invoice" : "public/js/sales_invoice.js",
-    "Sales Invoice Timesheet" : "public/js/sales_invoice_timesheets.js",
-    "Maintenance Visit" : "public/js/maintenance_visit.js",
-    "Event" : "public/js/event.js",
-    "Item" : "public/js/item.js",
-    "Customer" : "public/js/customer.js"
+	"Communication": "public/js/communication.js",
+	"Issue": "public/js/issue.js",
+	"Task": "public/js/task.js",
+	"Project": "public/js/project.js",
+	"Sales Invoice": "public/js/sales_invoice.js",
+	"Sales Invoice Timesheet": "public/js/sales_invoice_timesheets.js",
+	"Maintenance Visit": "public/js/maintenance_visit.js",
+	"Event": "public/js/event.js",
+	"Item": "public/js/item.js",
+	"Customer": "public/js/customer.js",
+	"Address": "public/js/address.js",
 }
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
@@ -81,7 +85,8 @@ doctype_js = {
 # ------------
 
 # before_install = "it_management.install.before_install"
-# after_install = "it_management.install.after_install"
+after_install = "it_management.install.after_install"
+after_migrate = "it_management.install.after_migrate"
 
 # Uninstalatiom
 
@@ -109,13 +114,11 @@ before_uninstall = "it_management.it_management.server_script.delete_custom_fiel
 # ---------------
 # Hook on document methods and events
 
-# doc_events = {
-# 	"*": {
-# 		"on_update": "method",
-# 		"on_cancel": "method",
-# 		"on_trash": "method"
-#	}
-# }
+doc_events = {
+	"Address": {
+		"on_update": "it_management.it_management.utils.geocoding.geocode_address_on_update",
+	},
+}
 
 # Scheduled Tasks
 # ---------------

--- a/it_management/install.py
+++ b/it_management/install.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+
+def after_install():
+	_ensure_map_view_setup()
+
+
+def after_migrate():
+	_ensure_map_view_setup()
+
+
+def _ensure_map_view_setup():
+	from it_management.it_management.utils.address_geo_fields import ensure_address_geo_fields
+
+	ensure_address_geo_fields()

--- a/it_management/it_management/doctype/it_management_settings/it_management_settings.json
+++ b/it_management/it_management/doctype/it_management_settings/it_management_settings.json
@@ -5,7 +5,10 @@
  "engine": "InnoDB",
  "field_order": [
   "section_erpnext_integration",
-  "use_erpnext_links"
+  "use_erpnext_links",
+  "section_map_view",
+  "auto_geocode_addresses",
+  "nominatim_url"
  ],
  "fields": [
   {
@@ -14,16 +17,35 @@
    "label": "ERPNext Integration"
   },
   {
+   "default": "1",
+   "description": "If enabled, use standard ERPNext doctypes (Customer, Item, etc.). If disabled, IT Management will work standalone with Frappe only.",
    "fieldname": "use_erpnext_links",
    "fieldtype": "Check",
-   "label": "Use ERPNext Link Fields",
-   "default": 1,
-   "description": "If enabled, use standard ERPNext doctypes (Customer, Item, etc.). If disabled, IT Management will work standalone with Frappe only."
+   "label": "Use ERPNext Link Fields"
+  },
+  {
+   "fieldname": "section_map_view",
+   "fieldtype": "Section Break",
+   "label": "Map View"
+  },
+  {
+   "default": "1",
+   "description": "When an Address is saved, look up latitude/longitude via Nominatim (OpenStreetMap) so Map View can place markers. Addresses marked as Manual Coordinates are skipped.",
+   "fieldname": "auto_geocode_addresses",
+   "fieldtype": "Check",
+   "label": "Auto-Geocode Addresses"
+  },
+  {
+   "default": "https://nominatim.openstreetmap.org",
+   "description": "Nominatim endpoint used for geocoding. Use a self-hosted instance for production volume; the public OSM service has strict usage limits.",
+   "fieldname": "nominatim_url",
+   "fieldtype": "Data",
+   "label": "Nominatim URL"
   }
  ],
  "issingle": 1,
- "modified": "2020-11-10 12:11:06.060372",
- "modified_by": "marius.widmann@tueit.de",
+ "modified": "2026-07-18 23:30:00.000000",
+ "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management Settings",
  "owner": "Administrator",

--- a/it_management/it_management/server_script/delete_custom_fields.py
+++ b/it_management/it_management/server_script/delete_custom_fields.py
@@ -1,47 +1,51 @@
 import frappe
 
-def delete_custom_fields():
-    custom_fields = {
-        "Task": [
-            "it_landscape",
-            "customer",
-            "user_account",
-            "configuration_item",
-            "github_sync_id",
-            "it_management_table",
-            "section_break_42"
-        ],
-        "Delivery Note": ["issue"],
-        "Issue": [
-            "it_landscape",
-            "filter_based_on_customer",
-            "full_customer_name",
-            "task",
-            "contact_html",
-            "configuration_item",
-            "it_management_table",
-            "section_break_43"
-        ],
-        "Maintenance Schedule" : [
-            "it_management_table",
-            "section_break_9"
-        ],
-        "IT Service Report" : [
-            "employee_name"
-        ],
-        "Project" : [
-            "it_landscape",
-            "customer_name",
-            "configuration_item",
-            "github_sync_id"
-        ]
-    }
 
-    for doctype, fields in custom_fields.items():
-        for fieldname in fields:
-            custom_field_name = f"{doctype}-{fieldname}"
-            try:
-                frappe.delete_doc("Custom Field", custom_field_name, force=True)
-                print(f"Custom Field {custom_field_name} deleted")
-            except frappe.DoesNotExistError:
-                print(f"Custom Field {custom_field_name} does not exist")
+def delete_custom_fields():
+	custom_fields = {
+		"Task": [
+			"it_landscape",
+			"customer",
+			"user_account",
+			"configuration_item",
+			"github_sync_id",
+			"it_management_table",
+			"section_break_42",
+		],
+		"Delivery Note": ["issue"],
+		"Issue": [
+			"it_landscape",
+			"filter_based_on_customer",
+			"full_customer_name",
+			"task",
+			"contact_html",
+			"configuration_item",
+			"it_management_table",
+			"section_break_43",
+		],
+		"Maintenance Schedule": ["it_management_table", "section_break_9"],
+		"IT Service Report": ["employee_name"],
+		"Project": [
+			"it_landscape",
+			"customer_name",
+			"configuration_item",
+			"github_sync_id",
+		],
+		"Address": [
+			"itm_map_section",
+			"latitude",
+			"longitude",
+			"column_break_itm_map",
+			"itm_manual_coordinates",
+			"itm_geocode_hash",
+		],
+	}
+
+	for doctype, fields in custom_fields.items():
+		for fieldname in fields:
+			custom_field_name = "{0}-{1}".format(doctype, fieldname)
+			try:
+				frappe.delete_doc("Custom Field", custom_field_name, force=True)
+				print("Custom Field {0} deleted".format(custom_field_name))
+			except frappe.DoesNotExistError:
+				print("Custom Field {0} does not exist".format(custom_field_name))

--- a/it_management/it_management/utils/address_geo_fields.py
+++ b/it_management/it_management/utils/address_geo_fields.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+"""Custom fields on Address that power Map View + geocoding."""
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+ADDRESS_GEO_CUSTOM_FIELDS = {
+	"Address": [
+		{
+			"fieldname": "itm_map_section",
+			"fieldtype": "Section Break",
+			"label": "Map Location",
+			"insert_after": "disabled",
+			"collapsible": 1,
+		},
+		{
+			"fieldname": "latitude",
+			"fieldtype": "Float",
+			"label": "Latitude",
+			"insert_after": "itm_map_section",
+			"precision": "9",
+		},
+		{
+			"fieldname": "longitude",
+			"fieldtype": "Float",
+			"label": "Longitude",
+			"insert_after": "latitude",
+			"precision": "9",
+		},
+		{
+			"fieldname": "column_break_itm_map",
+			"fieldtype": "Column Break",
+			"insert_after": "longitude",
+		},
+		{
+			"fieldname": "itm_manual_coordinates",
+			"fieldtype": "Check",
+			"label": "Manual Coordinates",
+			"insert_after": "column_break_itm_map",
+			"description": "If checked, auto-geocoding will not overwrite latitude/longitude.",
+			"default": "0",
+		},
+		{
+			"fieldname": "itm_geocode_hash",
+			"fieldtype": "Data",
+			"label": "Geocode Hash",
+			"insert_after": "itm_manual_coordinates",
+			"read_only": 1,
+			"hidden": 1,
+			"no_copy": 1,
+		},
+	]
+}
+
+
+def ensure_address_geo_fields():
+	"""Create Address custom fields required for Map View (idempotent)."""
+	create_custom_fields(ADDRESS_GEO_CUSTOM_FIELDS, update=True)
+	frappe.clear_cache(doctype="Address")
+
+
+def remove_address_geo_fields():
+	"""Remove Address geo custom fields (used on app uninstall)."""
+	for field in ADDRESS_GEO_CUSTOM_FIELDS["Address"]:
+		fieldname = field["fieldname"]
+		custom_field_name = "Address-{0}".format(fieldname)
+		if frappe.db.exists("Custom Field", custom_field_name):
+			frappe.delete_doc("Custom Field", custom_field_name, force=1, ignore_permissions=True)

--- a/it_management/it_management/utils/geocoding.py
+++ b/it_management/it_management/utils/geocoding.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+"""Geocode Frappe Address documents via Nominatim (OpenStreetMap)."""
+
+from __future__ import unicode_literals
+
+import hashlib
+
+import frappe
+import requests
+from frappe import _
+from frappe.utils import cint, flt
+
+
+ADDRESS_GEO_FIELDS = (
+	"address_line1",
+	"address_line2",
+	"city",
+	"county",
+	"state",
+	"pincode",
+	"country",
+)
+
+DEFAULT_NOMINATIM_URL = "https://nominatim.openstreetmap.org"
+
+
+def get_geocoding_settings():
+	"""Return geocoding options from IT Management Settings (with defaults)."""
+	settings = frappe.db.get_singles_dict("IT Management Settings") or {}
+	return {
+		"auto_geocode_addresses": cint(settings.get("auto_geocode_addresses", 1)),
+		"nominatim_url": (settings.get("nominatim_url") or DEFAULT_NOMINATIM_URL).rstrip("/"),
+	}
+
+
+def cstr_strip(value):
+	return str(value).strip()
+
+
+def build_address_query(address):
+	"""Build a Nominatim search string from Address fields."""
+	parts = []
+	for fieldname in ADDRESS_GEO_FIELDS:
+		value = address.get(fieldname) if hasattr(address, "get") else getattr(address, fieldname, None)
+		if value:
+			parts.append(cstr_strip(value))
+	return ", ".join(parts)
+
+
+def address_query_hash(query):
+	"""Stable hash used to skip re-geocoding unchanged addresses."""
+	return hashlib.md5(query.encode("utf-8")).hexdigest()
+
+
+def _get_coord(address, fieldname):
+	value = address.get(fieldname) if hasattr(address, "get") else getattr(address, fieldname, None)
+	return flt(value)
+
+
+def has_coordinates(address):
+	return bool(_get_coord(address, "latitude") or _get_coord(address, "longitude"))
+
+
+def should_geocode(address, force=False):
+	"""Decide whether an Address needs (re)geocoding."""
+	if force:
+		return True
+
+	if cint(
+		address.get("itm_manual_coordinates")
+		if hasattr(address, "get")
+		else getattr(address, "itm_manual_coordinates", 0)
+	):
+		return False
+
+	query = build_address_query(address)
+	if not query:
+		return False
+
+	current_hash = (
+		address.get("itm_geocode_hash")
+		if hasattr(address, "get")
+		else getattr(address, "itm_geocode_hash", None)
+	)
+	# Matching hash means we already looked this address text up (hit or miss)
+	if current_hash == address_query_hash(query):
+		return False
+
+	return True
+
+
+def geocode_query(query, nominatim_url=None, raise_on_error=False):
+	"""
+	Forward-geocode a free-text query with Nominatim.
+
+	Returns (latitude, longitude) or (None, None).
+	"""
+	if not query:
+		return None, None
+
+	settings = get_geocoding_settings()
+	base_url = (nominatim_url or settings["nominatim_url"]).rstrip("/")
+	url = "{0}/search".format(base_url)
+
+	headers = {
+		"User-Agent": "it_management-frappe/1.0 (+https://github.com/phamos-eu/it_management)",
+		"Accept": "application/json",
+	}
+	params = {
+		"q": query,
+		"format": "json",
+		"limit": 1,
+	}
+
+	try:
+		response = requests.get(url, params=params, headers=headers, timeout=10)
+		response.raise_for_status()
+		results = response.json()
+	except Exception as exc:
+		frappe.log_error(
+			title=_("Address Geocoding Failed"),
+			message="{0}\n\nQuery: {1}".format(frappe.get_traceback(), query),
+		)
+		if raise_on_error:
+			frappe.throw(
+				_("Could not geocode address: {0}").format(str(exc)),
+				title=_("Geocoding Error"),
+			)
+		return None, None
+
+	if not results:
+		return None, None
+
+	return flt(results[0].get("lat")), flt(results[0].get("lon"))
+
+
+def apply_geocode_to_address(address, force=False, raise_on_error=False, throw_on_miss=False):
+	"""
+	Populate latitude/longitude on an Address document (not saved).
+
+	Returns True if coordinates were updated.
+	"""
+	if not should_geocode(address, force=force):
+		return False
+
+	query = build_address_query(address)
+	if not query:
+		return False
+
+	lat, lng = geocode_query(query, raise_on_error=raise_on_error)
+
+	if lat is None or lng is None:
+		if throw_on_miss:
+			frappe.throw(
+				_("No coordinates found for: {0}").format(query),
+				title=_("Geocoding Miss"),
+			)
+		# Remember the query so we do not hammer the geocoder on every save
+		address.itm_geocode_hash = address_query_hash(query)
+		return "miss"
+
+	address.latitude = lat
+	address.longitude = lng
+	address.itm_geocode_hash = address_query_hash(query)
+	return True
+
+
+def geocode_address_on_update(doc, method=None):
+	"""
+	doc_events hook: queue auto-geocoding after Address save.
+
+	Runs in the background so Nominatim latency does not block the form.
+	"""
+	settings = get_geocoding_settings()
+	if not settings["auto_geocode_addresses"]:
+		return
+
+	# Custom fields may not exist yet during early migrate
+	if not frappe.db.has_column("Address", "latitude"):
+		return
+
+	if cint(doc.get("itm_manual_coordinates")):
+		return
+
+	if not should_geocode(doc, force=False):
+		return
+
+	_enqueue_geocode(doc.name)
+
+
+def _enqueue_geocode(address_name):
+	"""Enqueue geocode job with kwargs compatible across Frappe v13–v15."""
+	method = "it_management.it_management.utils.geocoding.geocode_address"
+	kwargs = {
+		"name": address_name,
+		"force": 0,
+		"queue": "short",
+		"enqueue_after_commit": True,
+	}
+	try:
+		frappe.enqueue(
+			method,
+			deduplicate=True,
+			job_id="itm-geocode-{0}".format(address_name),
+			**kwargs
+		)
+	except TypeError:
+		# Older Frappe builds may not support deduplicate/job_id
+		frappe.enqueue(method, **kwargs)
+
+
+@frappe.whitelist()
+def geocode_address(name, force=1):
+	"""Whitelisted / background: geocode a saved Address and persist coordinates."""
+	frappe.has_permission("Address", "write", throw=True)
+
+	doc = frappe.get_doc("Address", name)
+	result = apply_geocode_to_address(
+		doc, force=cint(force), raise_on_error=cint(force), throw_on_miss=cint(force)
+	)
+	# Persist successful lookups and "miss" hashes (avoid repeat calls)
+	if result:
+		doc.flags.ignore_permissions = True
+		doc.save()
+	return {
+		"name": doc.name,
+		"latitude": getattr(doc, "latitude", None),
+		"longitude": getattr(doc, "longitude", None),
+		"updated": result is True,
+	}

--- a/it_management/it_management/utils/map_view.py
+++ b/it_management/it_management/utils/map_view.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+"""Map View helpers for DocTypes that link to Address."""
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe import _
+from frappe.utils.data import flt
+
+# DocType → Link fieldname pointing to Address
+ADDRESS_LINK_FIELDS = {
+	"ITM Location": "itm_location_address",
+	"Location": "address",
+	"ITM Trip": "destination",
+	"Trip": "destination",
+	"IT Service Report": "destination",
+}
+
+
+def create_point_feature(name, latitude, longitude, title=None, address=None):
+	"""Build a GeoJSON Point Feature for Map View markers."""
+	properties = {"name": name}
+	if title:
+		properties["title"] = title
+	if address:
+		properties["address"] = address
+
+	return {
+		"type": "Feature",
+		"properties": properties,
+		"geometry": {
+			"type": "Point",
+			# GeoJSON order is longitude, latitude
+			"coordinates": [flt(longitude), flt(latitude)],
+		},
+	}
+
+
+def _get_address_coords(address_name):
+	"""Return (lat, lng, address_name) for a linked Address, or None."""
+	if not address_name:
+		return None
+
+	if not frappe.db.has_column("Address", "latitude"):
+		return None
+
+	row = frappe.db.get_value(
+		"Address",
+		address_name,
+		["name", "latitude", "longitude", "address_title"],
+		as_dict=True,
+	)
+	if not row:
+		return None
+
+	lat = flt(row.latitude)
+	lng = flt(row.longitude)
+	if not (lat or lng):
+		return None
+
+	return lat, lng, row.name
+
+
+def resolve_itm_location_address(location_name):
+	"""
+	Resolve the best Address for an ITM Location.
+
+	Site/Building use their own address; Floor/Room walk up to a parent
+	Site or Building that has an address.
+	"""
+	current = location_name
+	seen = set()
+
+	while current and current not in seen:
+		seen.add(current)
+		row = frappe.db.get_value(
+			"ITM Location",
+			current,
+			["name", "itm_location_address", "itm_parent_location", "location_type"],
+			as_dict=True,
+		)
+		if not row:
+			break
+
+		if row.itm_location_address:
+			return row.itm_location_address
+
+		current = row.itm_parent_location
+
+	return None
+
+
+def resolve_address_for_doc(doctype, doc):
+	"""Return Address name for a document, including ITM Location inheritance."""
+	if doctype == "ITM Location":
+		direct = doc.get(ADDRESS_LINK_FIELDS["ITM Location"])
+		if direct:
+			return direct
+		return resolve_itm_location_address(doc.name)
+
+	fieldname = ADDRESS_LINK_FIELDS.get(doctype)
+	if not fieldname:
+		return None
+	return doc.get(fieldname)
+
+
+@frappe.whitelist()
+def get_coords(doctype, filters=None, type=None):
+	"""
+	Return a GeoJSON FeatureCollection for Map View.
+
+	Used via frappe.listview_settings[doctype].get_coords_method for DocTypes
+	that store location as a Link to Address (with latitude/longitude).
+	"""
+	if not frappe.has_permission(doctype):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	# Address itself uses core coordinate fields
+	if doctype == "Address":
+		from frappe.geo.utils import get_coords as core_get_coords
+
+		return core_get_coords(doctype, filters, "coordinates")
+
+	address_field = ADDRESS_LINK_FIELDS.get(doctype)
+	if not address_field:
+		frappe.throw(
+			_("No Address link mapping configured for {0}").format(doctype),
+			title=_("Map View"),
+		)
+
+	from frappe.desk.reportview import get_filters_cond
+
+	conditions = get_filters_cond(doctype, filters, [], with_match_conditions=True)
+	# get_filters_cond returns " and ..." or ""
+	where_sql = conditions[4:] if conditions else "1=1"
+
+	# Fetch enough fields to resolve addresses
+	if doctype == "ITM Location":
+		fields = "name, itm_location_name as title, itm_location_address, itm_parent_location, location_type"
+	elif doctype == "Location":
+		fields = "name, title, address"
+	elif doctype in ("ITM Trip", "Trip", "IT Service Report"):
+		fields = "name, destination"
+	else:
+		fields = "name, `{0}`".format(address_field)
+
+	try:
+		rows = frappe.db.sql(
+			"SELECT {fields} FROM `tab{doctype}` WHERE {where_sql}".format(
+				fields=fields, doctype=doctype, where_sql=where_sql
+			),
+			as_dict=True,
+		)
+	except frappe.db.InternalError:
+		frappe.throw(
+			_("Could not load map coordinates for {0}").format(doctype),
+			title=_("Map View"),
+		)
+
+	features = []
+	for row in rows:
+		address_name = resolve_address_for_doc(doctype, row)
+		coords = _get_address_coords(address_name)
+		if not coords:
+			continue
+
+		lat, lng, address = coords
+		title = row.get("title") or row.get("itm_location_name") or row.name
+		features.append(
+			create_point_feature(
+				name=row.name,
+				latitude=lat,
+				longitude=lng,
+				title=title,
+				address=address,
+			)
+		)
+
+	return {"type": "FeatureCollection", "features": features}
+
+
+def get_map_enabled_doctypes():
+	"""DocTypes for which this app registers Map View via Address links."""
+	return list(ADDRESS_LINK_FIELDS.keys())

--- a/it_management/it_management/utils/test_map_view.py
+++ b/it_management/it_management/utils/test_map_view.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+import unittest
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from it_management.it_management.utils.geocoding import (
+	address_query_hash,
+	apply_geocode_to_address,
+	build_address_query,
+	should_geocode,
+)
+from it_management.it_management.utils.map_view import (
+	ADDRESS_LINK_FIELDS,
+	create_point_feature,
+	get_coords,
+	resolve_itm_location_address,
+)
+
+
+class TestMapViewHelpers(FrappeTestCase):
+	def test_create_point_feature_geojson_order(self):
+		feature = create_point_feature("LOC-1", latitude=52.52, longitude=13.405, title="Berlin")
+		self.assertEqual(feature["type"], "Feature")
+		self.assertEqual(feature["geometry"]["type"], "Point")
+		# GeoJSON is [longitude, latitude]
+		self.assertEqual(feature["geometry"]["coordinates"], [13.405, 52.52])
+		self.assertEqual(feature["properties"]["name"], "LOC-1")
+		self.assertEqual(feature["properties"]["title"], "Berlin")
+
+	def test_address_link_field_mapping(self):
+		self.assertEqual(ADDRESS_LINK_FIELDS["ITM Location"], "itm_location_address")
+		self.assertEqual(ADDRESS_LINK_FIELDS["Location"], "address")
+		self.assertEqual(ADDRESS_LINK_FIELDS["ITM Trip"], "destination")
+
+	def test_build_address_query(self):
+		query = build_address_query(
+			frappe._dict(
+				{
+					"address_line1": "Pariser Platz 1",
+					"city": "Berlin",
+					"pincode": "10117",
+					"country": "Germany",
+				}
+			)
+		)
+		self.assertEqual(query, "Pariser Platz 1, Berlin, 10117, Germany")
+		self.assertEqual(address_query_hash(query), address_query_hash(query))
+
+	def test_should_geocode_respects_manual_flag_and_hash(self):
+		query = "Berlin, Germany"
+		address = frappe._dict(
+			{
+				"address_line1": "Berlin",
+				"country": "Germany",
+				"latitude": 52.52,
+				"longitude": 13.4,
+				"itm_geocode_hash": address_query_hash(query),
+				"itm_manual_coordinates": 0,
+			}
+		)
+		self.assertFalse(should_geocode(address))
+
+		# Remembered miss (hash set, no coordinates) should not retry
+		address.latitude = None
+		address.longitude = None
+		self.assertFalse(should_geocode(address))
+
+		address.itm_manual_coordinates = 1
+		self.assertFalse(should_geocode(address))
+		self.assertTrue(should_geocode(address, force=True))
+
+		address.itm_manual_coordinates = 0
+		address.city = "Munich"
+		self.assertTrue(should_geocode(address))
+
+	@patch("it_management.it_management.utils.geocoding.geocode_query")
+	def test_apply_geocode_sets_coordinates(self, mocked_geocode):
+		mocked_geocode.return_value = (48.8566, 2.3522)
+		address = frappe._dict(
+			{
+				"address_line1": "Paris",
+				"country": "France",
+				"latitude": None,
+				"longitude": None,
+				"itm_manual_coordinates": 0,
+				"itm_geocode_hash": None,
+			}
+		)
+		updated = apply_geocode_to_address(address, force=True)
+		self.assertTrue(updated)
+		self.assertEqual(address.latitude, 48.8566)
+		self.assertEqual(address.longitude, 2.3522)
+		self.assertTrue(address.itm_geocode_hash)
+
+
+class TestMapViewCoordsIntegration(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		from it_management.it_management.utils.address_geo_fields import ensure_address_geo_fields
+
+		ensure_address_geo_fields()
+
+	def test_get_coords_for_itm_location(self):
+		if not frappe.db.exists("Country", "Germany"):
+			frappe.get_doc({"doctype": "Country", "country_name": "Germany", "code": "de"}).insert(
+				ignore_permissions=True
+			)
+
+		address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "ITM Map Test Site",
+				"address_type": "Office",
+				"address_line1": "Teststrasse 1",
+				"city": "Berlin",
+				"country": "Germany",
+				"latitude": 52.52,
+				"longitude": 13.405,
+				"itm_manual_coordinates": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		location = frappe.get_doc(
+			{
+				"doctype": "ITM Location",
+				"itm_location_name": "ITM Map Test Site Loc",
+				"location_type": "Site",
+				"itm_location_address": address.name,
+			}
+		).insert(ignore_permissions=True)
+
+		self.addCleanup(lambda: frappe.delete_doc("ITM Location", location.name, force=1))
+		self.addCleanup(lambda: frappe.delete_doc("Address", address.name, force=1))
+
+		result = get_coords("ITM Location", [["ITM Location", "name", "=", location.name]], None)
+		self.assertEqual(result["type"], "FeatureCollection")
+		self.assertEqual(len(result["features"]), 1)
+		self.assertEqual(result["features"][0]["properties"]["name"], location.name)
+		self.assertEqual(result["features"][0]["geometry"]["coordinates"], [13.405, 52.52])
+
+	def test_resolve_address_from_parent_site(self):
+		if not frappe.db.exists("Country", "Germany"):
+			frappe.get_doc({"doctype": "Country", "country_name": "Germany", "code": "de"}).insert(
+				ignore_permissions=True
+			)
+
+		address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": "ITM Map Parent Addr",
+				"address_type": "Office",
+				"address_line1": "Parent 1",
+				"city": "Hamburg",
+				"country": "Germany",
+				"latitude": 53.55,
+				"longitude": 9.99,
+				"itm_manual_coordinates": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		site = frappe.get_doc(
+			{
+				"doctype": "ITM Location",
+				"itm_location_name": "ITM Map Parent Site",
+				"location_type": "Site",
+				"itm_location_address": address.name,
+			}
+		).insert(ignore_permissions=True)
+
+		building = frappe.get_doc(
+			{
+				"doctype": "ITM Location",
+				"itm_location_name": "ITM Map Child Building",
+				"location_type": "Building",
+				"itm_parent_location": site.name,
+			}
+		).insert(ignore_permissions=True)
+
+		self.addCleanup(lambda: frappe.delete_doc("ITM Location", building.name, force=1))
+		self.addCleanup(lambda: frappe.delete_doc("ITM Location", site.name, force=1))
+		self.addCleanup(lambda: frappe.delete_doc("Address", address.name, force=1))
+
+		self.assertEqual(resolve_itm_location_address(building.name), address.name)
+
+		result = get_coords("ITM Location", [["ITM Location", "name", "=", building.name]], None)
+		self.assertEqual(len(result["features"]), 1)
+		self.assertEqual(result["features"][0]["geometry"]["coordinates"], [9.99, 53.55])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -15,3 +15,4 @@ it_management.patches.0_4.set_itm_host_item_deployment_physical
 it_management.patches.0_4.migrate_itm_lifecycle_health_status
 it_management.patches.0_4.set_itm_location_type_site
 it_management.patches.0_4.reload_itm_workspace_network_card
+it_management.patches.0_4.add_address_map_geo_fields

--- a/it_management/patches/0_4/add_address_map_geo_fields.py
+++ b/it_management/patches/0_4/add_address_map_geo_fields.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+
+def execute():
+	"""Add latitude/longitude custom fields on Address for Map View."""
+	from it_management.it_management.utils.address_geo_fields import ensure_address_geo_fields
+
+	ensure_address_geo_fields()

--- a/it_management/public/build.json
+++ b/it_management/public/build.json
@@ -1,5 +1,8 @@
 {
 	"js/itm_utils.js": [
 		"public/js/itm_utils.js"
+	],
+	"js/map_view.js": [
+		"public/js/map_view.js"
 	]
 }

--- a/it_management/public/js/address.js
+++ b/it_management/public/js/address.js
@@ -1,0 +1,41 @@
+// Copyright (c) 2026, IT Management contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Address", {
+	refresh(frm) {
+		if (frm.is_new()) {
+			return;
+		}
+
+		frm.add_custom_button(__("Geocode Address"), () => {
+			frappe.call({
+				method: "it_management.it_management.utils.geocoding.geocode_address",
+				args: {
+					name: frm.doc.name,
+					force: 1,
+				},
+				freeze: true,
+				freeze_message: __("Looking up coordinates…"),
+				callback(r) {
+					if (!r.message) {
+						return;
+					}
+					frm.reload_doc();
+					frappe.show_alert({
+						message: __("Coordinates updated"),
+						indicator: "green",
+					});
+				},
+			});
+		});
+	},
+
+	itm_manual_coordinates(frm) {
+		if (frm.doc.itm_manual_coordinates) {
+			frappe.show_alert({
+				message: __("Auto-geocoding disabled for this address"),
+				indicator: "orange",
+			});
+		}
+	},
+});

--- a/it_management/public/js/map_view.js
+++ b/it_management/public/js/map_view.js
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, IT Management contributors
+// For license information, please see license.txt
+
+/**
+ * Enable Frappe Map View for DocTypes that link to Address.
+ *
+ * Frappe already ships Map View (Leaflet + OpenStreetMap). It appears in the
+ * view switcher when listview_settings.get_coords_method is set, or when the
+ * DocType has latitude/longitude / Geolocation fields.
+ *
+ * Markers are auto-framed with padding so two hits in Germany stay framed
+ * tightly, while hits in Paris + London expand the viewport with a border.
+ */
+
+frappe.provide("frappe.listview_settings");
+frappe.provide("it_management.map_view");
+
+it_management.map_view.ADDRESS_LINK_DOCTYPES = [
+	"ITM Location",
+	"Location",
+	"ITM Trip",
+	"Trip",
+	"IT Service Report",
+];
+
+it_management.map_view.COORDS_METHOD =
+	"it_management.it_management.utils.map_view.get_coords";
+
+it_management.map_view.FIT_BOUNDS_OPTIONS = {
+	padding: [48, 48],
+	maxZoom: 16,
+};
+
+(function register_address_map_views() {
+	it_management.map_view.ADDRESS_LINK_DOCTYPES.forEach((doctype) => {
+		const existing = frappe.listview_settings[doctype] || {};
+		frappe.listview_settings[doctype] = Object.assign({}, existing, {
+			get_coords_method: it_management.map_view.COORDS_METHOD,
+		});
+	});
+})();
+
+/** Fit map frame to markers with a small border around the hit area. */
+it_management.map_view.fit_marker_bounds = function (map, marker_layer) {
+	if (!map || !marker_layer) {
+		return;
+	}
+	const bounds = marker_layer.getBounds();
+	if (!bounds || !bounds.isValid()) {
+		return;
+	}
+	map.fitBounds(bounds, it_management.map_view.FIT_BOUNDS_OPTIONS);
+};
+
+/** Patch core MapView once it is available so all map views get padded bounds. */
+it_management.map_view.patch_fit_bounds = function () {
+	if (!frappe.views || !frappe.views.MapView) {
+		return;
+	}
+	if (frappe.views.MapView.prototype.__itm_fit_bounds_patched) {
+		return;
+	}
+
+	const original = frappe.views.MapView.prototype.render_map_data;
+	frappe.views.MapView.prototype.render_map_data = function () {
+		if (this.markerLayer) {
+			this.map.removeLayer(this.markerLayer);
+		}
+
+		if (!(this.coords && this.coords.features && this.coords.features.length)) {
+			return;
+		}
+
+		this.markerLayer = L.featureGroup();
+
+		this.coords.features.forEach((feature) => {
+			const label =
+				(feature.properties &&
+					(feature.properties.title || feature.properties.name)) ||
+				"";
+			const popup = frappe.utils.get_form_link(
+				this.doctype,
+				feature.properties.name,
+				true,
+				label
+			);
+			const marker = L.geoJSON(feature).bindPopup(popup);
+			this.markerLayer.addLayer(marker);
+		});
+
+		this.markerLayer.addTo(this.map);
+		it_management.map_view.fit_marker_bounds(this.map, this.markerLayer);
+	};
+
+	// Keep a reference in case callers expect the original
+	frappe.views.MapView.prototype.__itm_original_render_map_data = original;
+	frappe.views.MapView.prototype.__itm_fit_bounds_patched = true;
+};
+
+it_management.map_view.schedule_patch = function () {
+	it_management.map_view.patch_fit_bounds();
+	if (frappe.views && frappe.views.MapView && frappe.views.MapView.prototype.__itm_fit_bounds_patched) {
+		return;
+	}
+	// list.bundle (MapView) may load after app_include_js
+	setTimeout(it_management.map_view.schedule_patch, 400);
+};
+
+$(document).on("app_ready", () => {
+	it_management.map_view.schedule_patch();
+});
+
+if (frappe.router && frappe.router.on) {
+	frappe.router.on("change", () => {
+		it_management.map_view.patch_fit_bounds();
+	});
+}
+
+it_management.map_view.schedule_patch();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Map View** (same view switcher as List / Report / Tree) for DocTypes that store location as a Link to **Address**.

Frappe already ships Map View on Leaflet + OpenStreetMap. This app wires it up for address-based DocTypes and auto-frames markers to the hit area.

### What you get
- **Map** appears in the view menu for:
  - ITM Location
  - Location
  - ITM Trip / Trip
  - IT Service Report
  - Address (via new latitude/longitude fields)
- Markers are placed from Address coordinates
- The map **auto-fits** all markers with padding (two sites in Germany stay framed tightly; adding Paris + London expands the viewport)
- ITM Location Floor/Room markers inherit the parent Site/Building address when they have none of their own

### How coordinates are filled
- Custom fields on **Address**: Latitude, Longitude, Manual Coordinates
- Optional **auto-geocoding** via Nominatim (OpenStreetMap) on Address save (background job)
- Manual geocode button on the Address form
- Settings under **IT Management Settings → Map View** (enable/disable auto-geocode, Nominatim URL)

### Notes
- Prefer a self-hosted Nominatim for production volume; the public OSM endpoint has strict usage limits
- Check **Manual Coordinates** on an Address to stop auto-overwrite
- After migrate/install, open e.g. ITM Location → switch to **Map**

## Test plan
- [ ] `bench migrate` (creates Address geo custom fields)
- [ ] Create/open an Address, set a real street address, save (or click **Geocode Address**)
- [ ] Confirm latitude/longitude are filled
- [ ] Open **ITM Location** list → switch to **Map** → markers appear and the viewport fits them
- [ ] Filter to two nearby locations → frame is tight; add a far location → frame expands
- [ ] Floor/Room without own address still shows under the parent Site/Building marker when filtered in
- [ ] Disable auto-geocode in IT Management Settings and confirm saves no longer enqueue geocoding

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4febb2b4-30c5-4dd6-a994-8e8002e4f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4febb2b4-30c5-4dd6-a994-8e8002e4f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

