### PR TITLE
fix: ITM Location save — No Label is required

### DIFF
--- a/it_management/it_management/doctype/itm_location/itm_location.js
+++ b/it_management/it_management/doctype/itm_location/itm_location.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on('ITM Location', {
 	setup(frm) {
-		frm.set_query('itm_parent_location', () => {
+		frm.set_query('parent_itm_location', () => {
 			const expected = {
 				Building: 'Site',
 				Floor: 'Building',
@@ -30,17 +30,17 @@ frappe.ui.form.on('ITM Location', {
 	location_type(frm) {
 		frm.trigger('toggle_location_fields');
 		if (frm.doc.location_type === 'Site') {
-			frm.set_value('itm_parent_location', null);
+			frm.set_value('parent_itm_location', null);
 		}
 	},
 
-	itm_parent_location(frm) {
-		if (frm.doc.location_type === 'Site' || !frm.doc.itm_parent_location) {
+	parent_itm_location(frm) {
+		if (frm.doc.location_type === 'Site' || !frm.doc.parent_itm_location) {
 			return;
 		}
 		frappe.db.get_value(
 			'ITM Location',
-			frm.doc.itm_parent_location,
+			frm.doc.parent_itm_location,
 			'itm_landscape',
 			(r) => {
 				if (r) {
@@ -57,7 +57,7 @@ frappe.ui.form.on('ITM Location', {
 
 		frm.set_df_property('itm_landscape', 'read_only', is_site ? 0 : 1);
 		frm.set_df_property('itm_location_address', 'hidden', show_address ? 0 : 1);
-		frm.set_df_property('itm_parent_location', 'hidden', is_site ? 1 : 0);
-		frm.set_df_property('itm_parent_location', 'reqd', is_site ? 0 : 1);
+		frm.set_df_property('parent_itm_location', 'hidden', is_site ? 1 : 0);
+		frm.set_df_property('parent_itm_location', 'reqd', is_site ? 0 : 1);
 	},
 });

--- a/it_management/it_management/doctype/itm_location/itm_location.json
+++ b/it_management/it_management/doctype/itm_location/itm_location.json
@@ -12,12 +12,12 @@
   "location_type",
   "itm_landscape",
   "itm_location_address",
-  "itm_parent_location",
+  "parent_itm_location",
   "is_group",
   "disabled",
   "lft",
   "rgt",
-  "itm_old_parent"
+  "old_parent"
  ],
  "fields": [
   {
@@ -57,7 +57,7 @@
   {
    "depends_on": "eval:doc.location_type!='Site'",
    "description": "Required for Building (Site), Floor (Building), and Room (Floor).",
-   "fieldname": "itm_parent_location",
+   "fieldname": "parent_itm_location",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Parent Location",
@@ -95,7 +95,7 @@
    "read_only": 1
   },
   {
-   "fieldname": "itm_old_parent",
+   "fieldname": "old_parent",
    "fieldtype": "Link",
    "hidden": 1,
    "label": "Old Parent",
@@ -122,12 +122,12 @@
    "link_fieldname": "itm_location"
   }
  ],
- "modified": "2026-07-18 23:05:00.000000",
+ "modified": "2026-07-19 08:00:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Location",
  "naming_rule": "By fieldname",
- "nsm_parent_field": "itm_parent_location",
+ "nsm_parent_field": "parent_itm_location",
  "owner": "Administrator",
  "permissions": [
   {
@@ -158,5 +158,6 @@
  "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "itm_location_name"
 }

--- a/it_management/it_management/doctype/itm_location/itm_location.py
+++ b/it_management/it_management/doctype/itm_location/itm_location.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import _
+from frappe.desk.treeview import make_tree_args
 from frappe.utils.nestedset import NestedSet
 
 # Child type → required parent type
@@ -10,6 +11,13 @@ PARENT_TYPE = {
 	"Building": "Site",
 	"Floor": "Building",
 	"Room": "Floor",
+}
+
+# Parent type → child created under it in the tree
+CHILD_TYPE = {
+	"Site": "Building",
+	"Building": "Floor",
+	"Floor": "Room",
 }
 
 GROUP_TYPES = frozenset(("Site", "Building", "Floor"))
@@ -108,3 +116,42 @@ class ITMLocation(NestedSet):
 			""",
 			(self.itm_landscape, self.lft, self.rgt),
 		)
+
+
+@frappe.whitelist()
+def add_node():
+	"""Create an ITM Location from Tree View with hierarchy-aware defaults."""
+	args = make_tree_args(**frappe.form_dict)
+	_apply_tree_create_defaults(args)
+	doc = frappe.get_doc(args)
+	doc.insert()
+	return doc.name
+
+
+def _apply_tree_create_defaults(args):
+	"""Ensure parent + location_type match Site → Building → Floor → Room."""
+	parent = args.get("parent_itm_location")
+
+	# Tree root is labeled with the DocType name; treat as no parent
+	if parent in (None, "", args.get("doctype"), "ITM Location"):
+		parent = None
+		args["parent_itm_location"] = None
+		args["location_type"] = "Site"
+		return
+
+	parent_type = frappe.db.get_value("ITM Location", parent, "location_type")
+	if not parent_type:
+		frappe.throw(
+			_("Parent location {0} was not found.").format(parent),
+			title=_("Missing Parent Location"),
+		)
+
+	child_type = CHILD_TYPE.get(parent_type)
+	if not child_type:
+		frappe.throw(
+			_("Cannot add a child under a {0}.").format(_(parent_type)),
+			title=_("Invalid Hierarchy"),
+		)
+
+	args["parent_itm_location"] = parent
+	args["location_type"] = child_type

--- a/it_management/it_management/doctype/itm_location/itm_location.py
+++ b/it_management/it_management/doctype/itm_location/itm_location.py
@@ -16,7 +16,7 @@ GROUP_TYPES = frozenset(("Site", "Building", "Floor"))
 
 
 class ITMLocation(NestedSet):
-	nsm_parent_field = "itm_parent_location"
+	nsm_parent_field = "parent_itm_location"
 
 	def validate(self):
 		self._normalize_location_type()
@@ -39,7 +39,7 @@ class ITMLocation(NestedSet):
 
 	def _validate_hierarchy(self):
 		if self.location_type == "Site":
-			if self.itm_parent_location:
+			if self.parent_itm_location:
 				frappe.throw(
 					_("A Site cannot have a parent location."),
 					title=_("Invalid Hierarchy"),
@@ -47,7 +47,7 @@ class ITMLocation(NestedSet):
 			return
 
 		expected_parent_type = PARENT_TYPE.get(self.location_type)
-		if not self.itm_parent_location:
+		if not self.parent_itm_location:
 			frappe.throw(
 				_("{0} must have a parent {1}.").format(
 					_(self.location_type), _(expected_parent_type)
@@ -55,14 +55,14 @@ class ITMLocation(NestedSet):
 				title=_("Missing Parent Location"),
 			)
 
-		if self.itm_parent_location == self.name:
+		if self.parent_itm_location == self.name:
 			frappe.throw(
 				_("A location cannot be its own parent."),
 				title=_("Invalid Hierarchy"),
 			)
 
 		parent_type = frappe.db.get_value(
-			"ITM Location", self.itm_parent_location, "location_type"
+			"ITM Location", self.parent_itm_location, "location_type"
 		)
 		if parent_type != expected_parent_type:
 			frappe.throw(
@@ -85,7 +85,7 @@ class ITMLocation(NestedSet):
 			return
 
 		parent_landscape = frappe.db.get_value(
-			"ITM Location", self.itm_parent_location, "itm_landscape"
+			"ITM Location", self.parent_itm_location, "itm_landscape"
 		)
 		self.itm_landscape = parent_landscape
 

--- a/it_management/it_management/doctype/itm_location/itm_location_tree.js
+++ b/it_management/it_management/doctype/itm_location/itm_location_tree.js
@@ -1,11 +1,19 @@
 // Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 // For license information, please see license.txt
 
+frappe.provide("frappe.treeview_settings");
+
+const ITM_LOCATION_CHILD_TYPE = {
+	Site: "Building",
+	Building: "Floor",
+	Floor: "Room",
+};
+
 frappe.treeview_settings["ITM Location"] = {
 	breadcrumb: "IT Management",
 	title: __("ITM Location"),
 	get_tree_nodes: "frappe.desk.treeview.get_children",
-	add_tree_node: "frappe.desk.treeview.add_node",
+	add_tree_node: "it_management.it_management.doctype.itm_location.itm_location.add_node",
 	filters: [
 		{
 			fieldname: "itm_landscape",
@@ -14,6 +22,8 @@ frappe.treeview_settings["ITM Location"] = {
 			label: __("Landscape"),
 		},
 	],
+	// parent_itm_location is set by Tree View / add_node — do not put it in the dialog
+	ignore_fields: ["parent_itm_location"],
 	fields: [
 		{
 			fieldtype: "Data",
@@ -28,6 +38,7 @@ frappe.treeview_settings["ITM Location"] = {
 			options: "Site\nBuilding\nFloor\nRoom",
 			reqd: true,
 			default: "Site",
+			read_only: 1,
 		},
 		{
 			fieldtype: "Link",
@@ -36,21 +47,64 @@ frappe.treeview_settings["ITM Location"] = {
 			options: "ITM Landscape",
 			description: __("Set on Site only; inherited by child locations."),
 		},
-		{
-			fieldtype: "Check",
-			fieldname: "is_group",
-			label: __("Is Location Group"),
-			description: __("Set automatically from Location Type."),
-			default: 1,
-			hidden: 1,
-		},
-		{
-			fieldtype: "Link",
-			fieldname: "parent_itm_location",
-			label: __("Parent Location"),
-			options: "ITM Location",
-			hidden: 1,
-		},
 	],
-	ignore_fields: ["parent_itm_location"],
+	onload(treeview) {
+		frappe.treeview_settings["ITM Location"].treeview = treeview;
+		const original_new_node = treeview.new_node.bind(treeview);
+
+		treeview.new_node = function () {
+			const node = treeview.tree.get_selected_node();
+			if (!(node && node.expandable)) {
+				frappe.msgprint(__("Select a group {0} first.", [__("ITM Location")]));
+				return;
+			}
+
+			const open_dialog = (child_type) => {
+				treeview.opts.fields = [
+					{
+						fieldtype: "Data",
+						fieldname: "itm_location_name",
+						label: __("Location Name"),
+						reqd: true,
+					},
+					{
+						fieldtype: "Select",
+						fieldname: "location_type",
+						label: __("Location Type"),
+						options: child_type,
+						reqd: true,
+						default: child_type,
+						read_only: 1,
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "itm_landscape",
+						label: __("Landscape"),
+						options: "ITM Landscape",
+						description: __("Set on Site only; inherited by child locations."),
+						hidden: child_type === "Site" ? 0 : 1,
+					},
+				];
+				original_new_node();
+			};
+
+			if (node.is_root) {
+				open_dialog("Site");
+				return;
+			}
+
+			const parent_name = node.data && node.data.value ? node.data.value : node.label;
+			frappe.db.get_value("ITM Location", parent_name, "location_type", (r) => {
+				const parent_type = r && r.location_type;
+				const child_type = ITM_LOCATION_CHILD_TYPE[parent_type];
+				if (!child_type) {
+					frappe.msgprint(
+						__("Cannot add a child under a {0}.", [__(parent_type || _("location"))])
+					);
+					return;
+				}
+				open_dialog(child_type);
+			});
+		};
+	},
 };

--- a/it_management/it_management/doctype/itm_location/itm_location_tree.js
+++ b/it_management/it_management/doctype/itm_location/itm_location_tree.js
@@ -1,5 +1,56 @@
 // Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 // For license information, please see license.txt
 
-// frappe.treeview_settings["ITM Location"] = {
-// };
+frappe.treeview_settings["ITM Location"] = {
+	breadcrumb: "IT Management",
+	title: __("ITM Location"),
+	get_tree_nodes: "frappe.desk.treeview.get_children",
+	add_tree_node: "frappe.desk.treeview.add_node",
+	filters: [
+		{
+			fieldname: "itm_landscape",
+			fieldtype: "Link",
+			options: "ITM Landscape",
+			label: __("Landscape"),
+		},
+	],
+	fields: [
+		{
+			fieldtype: "Data",
+			fieldname: "itm_location_name",
+			label: __("Location Name"),
+			reqd: true,
+		},
+		{
+			fieldtype: "Select",
+			fieldname: "location_type",
+			label: __("Location Type"),
+			options: "Site\nBuilding\nFloor\nRoom",
+			reqd: true,
+			default: "Site",
+		},
+		{
+			fieldtype: "Link",
+			fieldname: "itm_landscape",
+			label: __("Landscape"),
+			options: "ITM Landscape",
+			description: __("Set on Site only; inherited by child locations."),
+		},
+		{
+			fieldtype: "Check",
+			fieldname: "is_group",
+			label: __("Is Location Group"),
+			description: __("Set automatically from Location Type."),
+			default: 1,
+			hidden: 1,
+		},
+		{
+			fieldtype: "Link",
+			fieldname: "parent_itm_location",
+			label: __("Parent Location"),
+			options: "ITM Location",
+			hidden: 1,
+		},
+	],
+	ignore_fields: ["parent_itm_location"],
+};

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -15,3 +15,4 @@ it_management.patches.0_4.set_itm_host_item_deployment_physical
 it_management.patches.0_4.migrate_itm_lifecycle_health_status
 it_management.patches.0_4.set_itm_location_type_site
 it_management.patches.0_4.reload_itm_workspace_network_card
+it_management.patches.0_4.rename_itm_location_nestedset_fields

--- a/it_management/patches/0_4/rename_itm_location_nestedset_fields.py
+++ b/it_management/patches/0_4/rename_itm_location_nestedset_fields.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Align ITM Location NestedSet field names with Frappe tree conventions.
+
+Tree view posts parent as parent_<scrub(doctype)> → parent_itm_location.
+NestedSet tracks moves via old_parent.
+"""
+
+import frappe
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Location"):
+		return
+
+	frappe.reload_doc("IT Management", "doctype", "itm_location", force=True)
+
+	if frappe.db.has_column("ITM Location", "itm_parent_location") and not frappe.db.has_column(
+		"ITM Location", "parent_itm_location"
+	):
+		rename_field("ITM Location", "itm_parent_location", "parent_itm_location")
+
+	if frappe.db.has_column("ITM Location", "itm_old_parent") and not frappe.db.has_column(
+		"ITM Location", "old_parent"
+	):
+		rename_field("ITM Location", "itm_old_parent", "old_parent")
+
+	# Keep NestedSet parent field pointer in sync on the DocType row
+	frappe.db.set_value(
+		"DocType",
+		"ITM Location",
+		{
+			"nsm_parent_field": "parent_itm_location",
+			"title_field": "itm_location_name",
+		},
+		update_modified=False,
+	)
+
+	frappe.clear_cache(doctype="ITM Location")
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Saving an **ITM Location** (especially from Tree) failed with **“No Label is required”**, and **Add Child** failed with **“Building must have a parent Site.”**

### Cause
1. Tree View posts the parent as `parent_<scrub(doctype)>` → `parent_itm_location`. The DocType used `itm_parent_location` / `itm_old_parent`, so tree create never wired parent/title into autoname correctly.
2. The Add Child dialog defaulted `location_type` to **Site**. Under a Site that either blocked the create or left Building without a usable parent path.

### Fix
- Rename NestedSet fields to Frappe conventions:
  - `itm_parent_location` → `parent_itm_location`
  - `itm_old_parent` → `old_parent`
- Set `title_field` to `itm_location_name`
- Configure treeview create fields; parent is not edited in the dialog
- On Add Child, derive type from parent: Site→Building, Building→Floor, Floor→Room
- Dedicated `add_node` whitelist that enforces parent + child type
- Migrate patch: `rename_itm_location_nestedset_fields`

### After merge
Run `bench migrate` so existing sites rename the DB columns.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

