### PR TITLE
feat: ITM Subnet IPv4 address design + conflict warnings

### DIFF
--- a/it_management/it_management/doctype/itm_subnet/itm_subnet.js
+++ b/it_management/it_management/doctype/itm_subnet/itm_subnet.js
@@ -18,6 +18,14 @@ frappe.ui.form.on('ITM Subnet', {
 		}));
 	},
 
+	network_address(frm) {
+		frm.trigger('recalculate_address_design');
+	},
+
+	prefix_length(frm) {
+		frm.trigger('recalculate_address_design');
+	},
+
 	itm_local_area_network(frm) {
 		if (!frm.doc.itm_local_area_network) {
 			return;
@@ -36,5 +44,59 @@ frappe.ui.form.on('ITM Subnet', {
 				}
 			}
 		);
+	},
+
+	recalculate_address_design(frm) {
+		if (
+			!frm.doc.network_address ||
+			frm.doc.prefix_length === undefined ||
+			frm.doc.prefix_length === null ||
+			frm.doc.prefix_length === ''
+		) {
+			return;
+		}
+
+		if (frm._itm_subnet_design_busy) {
+			return;
+		}
+		frm._itm_subnet_design_busy = true;
+
+		frappe.call({
+			method: 'it_management.it_management.doctype.itm_subnet.itm_subnet.calculate_address_design',
+			args: {
+				network_address: frm.doc.network_address,
+				prefix_length: frm.doc.prefix_length,
+			},
+			freeze: false,
+			callback(r) {
+				frm._itm_subnet_design_busy = false;
+				if (!r.message) {
+					return;
+				}
+				const d = r.message;
+				// Update model directly for normalized network to avoid event loops
+				frm.doc.network_address = d.network_address;
+				frm.doc.prefix_length = d.prefix_length;
+				frm.doc.subnet_mask = d.subnet_mask;
+				frm.doc.cidr = d.cidr;
+				frm.doc.first_usable = d.first_usable;
+				frm.doc.last_usable = d.last_usable;
+				frm.doc.broadcast = d.broadcast;
+				frm.doc.usable_hosts = d.usable_hosts;
+				[
+					'network_address',
+					'prefix_length',
+					'subnet_mask',
+					'cidr',
+					'first_usable',
+					'last_usable',
+					'broadcast',
+					'usable_hosts',
+				].forEach((field) => frm.refresh_field(field));
+			},
+			error() {
+				frm._itm_subnet_design_busy = false;
+			},
+		});
 	},
 });

--- a/it_management/it_management/doctype/itm_subnet/itm_subnet.json
+++ b/it_management/it_management/doctype/itm_subnet/itm_subnet.json
@@ -1,18 +1,27 @@
 {
  "actions": [],
- "allow_rename": 1,
- "autoname": "format:{subnet}-{itm_landscape}",
+ "allow_rename": 0,
+ "autoname": "hash",
  "creation": "2026-07-18 23:00:00.000000",
  "default_view": "List",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "subnet",
+  "network_address",
+  "prefix_length",
+  "subnet_mask",
+  "cidr",
+  "column_break_addr",
+  "lifecycle_status",
+  "first_usable",
+  "last_usable",
+  "broadcast",
+  "usable_hosts",
+  "context_section",
   "itm_local_area_network",
   "itm_landscape",
   "itm_location",
-  "column_break_1",
   "information_section",
   "gateway",
   "dhcp",
@@ -31,12 +40,81 @@
  ],
  "fields": [
   {
-   "description": "CIDR, e.g. 192.168.1.0/24",
-   "fieldname": "subnet",
+   "description": "IPv4 network address, e.g. 10.40.0.0",
+   "fieldname": "network_address",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Subnet",
+   "label": "Network Address",
    "reqd": 1
+  },
+  {
+   "default": "24",
+   "description": "CIDR prefix length (0–32)",
+   "fieldname": "prefix_length",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Prefix Length",
+   "non_negative": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "subnet_mask",
+   "fieldtype": "Data",
+   "label": "Subnet Mask",
+   "read_only": 1
+  },
+  {
+   "bold": 1,
+   "fieldname": "cidr",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "CIDR",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_addr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Implementing",
+   "fieldname": "lifecycle_status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Lifecycle Status",
+   "options": "Planned\nImplementing\nRunning\nStorage\nObsolete",
+   "reqd": 1
+  },
+  {
+   "fieldname": "first_usable",
+   "fieldtype": "Data",
+   "label": "First Usable",
+   "read_only": 1
+  },
+  {
+   "fieldname": "last_usable",
+   "fieldtype": "Data",
+   "label": "Last Usable",
+   "read_only": 1
+  },
+  {
+   "fieldname": "broadcast",
+   "fieldtype": "Data",
+   "label": "Broadcast",
+   "read_only": 1
+  },
+  {
+   "fieldname": "usable_hosts",
+   "fieldtype": "Int",
+   "label": "Usable Hosts",
+   "read_only": 1
+  },
+  {
+   "fieldname": "context_section",
+   "fieldtype": "Section Break",
+   "label": "Context"
   },
   {
    "fieldname": "itm_local_area_network",
@@ -66,10 +144,6 @@
    "in_standard_filter": 1,
    "label": "Location",
    "options": "ITM Location"
-  },
-  {
-   "fieldname": "column_break_1",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "information_section",
@@ -164,11 +238,11 @@
    "link_fieldname": "itm_subnet"
   }
  ],
- "modified": "2026-07-19 08:10:00.000000",
+ "modified": "2026-07-19 15:30:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Subnet",
- "naming_rule": "Expression",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -197,8 +271,11 @@
   }
  ],
  "row_format": "Dynamic",
+ "search_fields": "cidr,network_address,itm_landscape,lifecycle_status",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "cidr",
  "track_changes": 1
 }

--- a/it_management/it_management/doctype/itm_subnet/itm_subnet.py
+++ b/it_management/it_management/doctype/itm_subnet/itm_subnet.py
@@ -5,10 +5,30 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from it_management.it_management.utils.ipv4 import (
+	design_from_network_and_prefix,
+	ranges_overlap,
+)
+
+SUBNET_LIFECYCLE = ("Planned", "Implementing", "Running", "Storage", "Obsolete")
+
 
 class ITMSubnet(Document):
 	def validate(self):
+		self._normalize_lifecycle()
 		self._sync_from_lan()
+		self._apply_address_design()
+		self._warn_address_conflicts()
+		self._warn_vlan_conflicts()
+
+	def _normalize_lifecycle(self):
+		if not self.lifecycle_status:
+			self.lifecycle_status = "Implementing"
+		elif self.lifecycle_status not in SUBNET_LIFECYCLE:
+			frappe.throw(
+				_("Invalid lifecycle status {0}.").format(self.lifecycle_status),
+				title=_("Invalid Status"),
+			)
 
 	def _sync_from_lan(self):
 		"""Landscape (and empty location) always follow the selected LAN."""
@@ -30,3 +50,151 @@ class ITMSubnet(Document):
 		self.itm_landscape = lan.itm_landscape
 		if not self.itm_location and lan.itm_location:
 			self.itm_location = lan.itm_location
+
+	def _apply_address_design(self):
+		self._network_int = None
+		self._broadcast_int = None
+		try:
+			design = design_from_network_and_prefix(self.network_address, self.prefix_length)
+		except (ValueError, TypeError) as exc:
+			frappe.throw(
+				_("Invalid IPv4 network design: {0}").format(str(exc)),
+				title=_("Invalid Subnet"),
+			)
+
+		self.network_address = design["network_address"]
+		self.prefix_length = design["prefix_length"]
+		self.subnet_mask = design["subnet_mask"]
+		self.cidr = design["cidr"]
+		self.first_usable = design["first_usable"]
+		self.last_usable = design["last_usable"]
+		self.broadcast = design["broadcast"]
+		self.usable_hosts = design["usable_hosts"]
+		self._network_int = design["network_int"]
+		self._broadcast_int = design["broadcast_int"]
+
+	def _warn_address_conflicts(self):
+		if not self.itm_landscape or self._network_int is None:
+			return
+
+		others = frappe.get_all(
+			"ITM Subnet",
+			filters={
+				"itm_landscape": self.itm_landscape,
+				"name": ["!=", self.name or ""],
+				"network_address": ["!=", ""],
+			},
+			fields=["name", "cidr", "network_address", "prefix_length", "lifecycle_status"],
+		)
+
+		messages = []
+		strong = False
+		for other in others:
+			try:
+				other_design = design_from_network_and_prefix(
+					other.network_address, other.prefix_length
+				)
+			except (ValueError, TypeError):
+				continue
+
+			if not ranges_overlap(
+				self._network_int,
+				self._broadcast_int,
+				other_design["network_int"],
+				other_design["broadcast_int"],
+			):
+				continue
+
+			exact = self.cidr == other_design["cidr"]
+			involves_running = (
+				self.lifecycle_status == "Running" or other.lifecycle_status == "Running"
+			)
+			if involves_running:
+				strong = True
+
+			if exact:
+				template = _(
+					"Duplicate CIDR {0} also used by {1} ({2})."
+				)
+			else:
+				template = _(
+					"Address range overlaps {0} on {1} ({2})."
+				)
+			messages.append(
+				template.format(
+					frappe.bold(other_design["cidr"]),
+					frappe.bold(other.name),
+					_(other.lifecycle_status or "Unknown"),
+				)
+			)
+
+		if not messages:
+			return
+
+		title = (
+			_("Running subnet address conflict")
+			if strong
+			else _("Subnet address conflict")
+		)
+		intro = (
+			_("Warning: one or more conflicts involve a Running subnet. Save is still allowed.")
+			if strong
+			else _("Warning: overlapping or duplicate subnets in this landscape. Save is still allowed.")
+		)
+		frappe.msgprint(
+			intro + "<br><br>" + "<br>".join(messages),
+			title=title,
+			indicator="red" if strong else "orange",
+			alert=True,
+		)
+
+	def _warn_vlan_conflicts(self):
+		if not self.itm_landscape or self.vlan_tag in (None, ""):
+			return
+
+		others = frappe.get_all(
+			"ITM Subnet",
+			filters={
+				"itm_landscape": self.itm_landscape,
+				"name": ["!=", self.name or ""],
+				"vlan_tag": self.vlan_tag,
+			},
+			fields=["name", "cidr", "lifecycle_status", "vlan_tag"],
+		)
+		if not others:
+			return
+
+		strong = self.lifecycle_status == "Running" or any(
+			row.lifecycle_status == "Running" for row in others
+		)
+		lines = [
+			_("{0} ({1}) uses VLAN {2}.").format(
+				frappe.bold(row.cidr or row.name),
+				_(row.lifecycle_status or "Unknown"),
+				row.vlan_tag,
+			)
+			for row in others
+		]
+		intro = (
+			_("Warning: VLAN tag conflict involves a Running subnet. Save is still allowed.")
+			if strong
+			else _("Warning: VLAN tag already used in this landscape. Save is still allowed.")
+		)
+		frappe.msgprint(
+			intro + "<br><br>" + "<br>".join(lines),
+			title=_("Running VLAN conflict") if strong else _("VLAN conflict"),
+			indicator="red" if strong else "orange",
+			alert=True,
+		)
+
+
+@frappe.whitelist()
+def calculate_address_design(network_address=None, prefix_length=None):
+	"""Return derived IPv4 design fields for the Subnet form."""
+	try:
+		return design_from_network_and_prefix(network_address, prefix_length)
+	except (ValueError, TypeError) as exc:
+		frappe.throw(
+			_("Invalid IPv4 network design: {0}").format(str(exc)),
+			title=_("Invalid Subnet"),
+		)

--- a/it_management/it_management/utils/ipv4.py
+++ b/it_management/it_management/utils/ipv4.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""IPv4 helpers for ITM Subnet address design."""
+
+from __future__ import unicode_literals
+
+import ipaddress
+
+
+def parse_cidr(value):
+	"""
+	Parse a CIDR string into a normalized IPv4Network.
+
+	Returns None if value is empty; raises ValueError if invalid.
+	"""
+	if not value:
+		return None
+	return ipaddress.ip_network(str(value).strip(), strict=False)
+
+
+def design_from_network_and_prefix(network_address, prefix_length):
+	"""
+	Build a normalized IPv4 design dict from network address + prefix.
+
+	Raises ValueError on invalid input.
+	"""
+	if network_address in (None, ""):
+		raise ValueError("Network address is required")
+	if prefix_length in (None, ""):
+		raise ValueError("Prefix length is required")
+
+	prefix = int(prefix_length)
+	if prefix < 0 or prefix > 32:
+		raise ValueError("Prefix length must be between 0 and 32")
+
+	network = ipaddress.ip_network(f"{str(network_address).strip()}/{prefix}", strict=False)
+	return network_to_design(network)
+
+
+def design_from_cidr(cidr):
+	"""Build a normalized IPv4 design dict from a CIDR string."""
+	network = parse_cidr(cidr)
+	if network is None:
+		raise ValueError("CIDR is required")
+	return network_to_design(network)
+
+
+def network_to_design(network):
+	"""Convert an IPv4Network to the ITM Subnet design field values."""
+	if network.version != 4:
+		raise ValueError("Only IPv4 is supported")
+
+	hosts = list(network.hosts())
+	if network.prefixlen >= 31:
+		# /31 and /32 have no classic usable host range
+		first_usable = str(network.network_address)
+		last_usable = str(network.broadcast_address)
+		usable_hosts = int(network.num_addresses)
+	else:
+		first_usable = str(hosts[0])
+		last_usable = str(hosts[-1])
+		usable_hosts = len(hosts)
+
+	return {
+		"network_address": str(network.network_address),
+		"prefix_length": network.prefixlen,
+		"subnet_mask": str(network.netmask),
+		"cidr": str(network),
+		"first_usable": first_usable,
+		"last_usable": last_usable,
+		"broadcast": str(network.broadcast_address),
+		"usable_hosts": usable_hosts,
+		"network_int": int(network.network_address),
+		"broadcast_int": int(network.broadcast_address),
+	}
+
+
+def ranges_overlap(a_start, a_end, b_start, b_end):
+	"""Inclusive integer range overlap."""
+	return a_start <= b_end and b_start <= a_end

--- a/it_management/it_management/utils/test_ipv4.py
+++ b/it_management/it_management/utils/test_ipv4.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+import unittest
+
+from it_management.it_management.utils.ipv4 import (
+	design_from_cidr,
+	design_from_network_and_prefix,
+	ranges_overlap,
+)
+
+
+class TestIPv4Design(unittest.TestCase):
+	def test_normalizes_network_address(self):
+		design = design_from_network_and_prefix("10.40.1.0", 23)
+		self.assertEqual(design["network_address"], "10.40.0.0")
+		self.assertEqual(design["subnet_mask"], "255.255.254.0")
+		self.assertEqual(design["cidr"], "10.40.0.0/23")
+		self.assertEqual(design["usable_hosts"], 510)
+
+	def test_slash_24(self):
+		design = design_from_cidr("192.168.1.10/24")
+		self.assertEqual(design["network_address"], "192.168.1.0")
+		self.assertEqual(design["first_usable"], "192.168.1.1")
+		self.assertEqual(design["last_usable"], "192.168.1.254")
+		self.assertEqual(design["broadcast"], "192.168.1.255")
+
+	def test_overlap_detection(self):
+		a = design_from_cidr("10.40.0.0/23")
+		b = design_from_cidr("10.40.1.0/24")
+		c = design_from_cidr("10.50.0.0/24")
+		self.assertTrue(
+			ranges_overlap(a["network_int"], a["broadcast_int"], b["network_int"], b["broadcast_int"])
+		)
+		self.assertFalse(
+			ranges_overlap(a["network_int"], a["broadcast_int"], c["network_int"], c["broadcast_int"])
+		)

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -18,3 +18,4 @@ it_management.patches.0_4.reload_itm_workspace_network_card
 it_management.patches.0_4.add_address_map_geo_fields
 it_management.patches.0_4.rename_itm_location_nestedset_fields
 it_management.patches.0_4.migrate_itm_subnet_lan_link
+it_management.patches.0_4.migrate_itm_subnet_address_model

--- a/it_management/patches/0_4/migrate_itm_subnet_address_model.py
+++ b/it_management/patches/0_4/migrate_itm_subnet_address_model.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Migrate ITM Subnet from free-text CIDR (`subnet`) to designed IPv4 fields.
+
+Also sets lifecycle_status default and DocType title/autoname metadata.
+"""
+
+import frappe
+
+from it_management.it_management.utils.ipv4 import design_from_cidr, design_from_network_and_prefix
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Subnet"):
+		return
+
+	legacy_rows = []
+	if frappe.db.has_column("ITM Subnet", "subnet"):
+		legacy_rows = frappe.db.sql(
+			"""
+			SELECT name, subnet, itm_landscape
+			FROM `tabITM Subnet`
+			WHERE IFNULL(subnet, '') != ''
+			""",
+			as_dict=True,
+		)
+
+	frappe.reload_doc("IT Management", "doctype", "itm_subnet", force=True)
+
+	if frappe.db.has_column("ITM Subnet", "lifecycle_status"):
+		frappe.db.sql(
+			"""
+			UPDATE `tabITM Subnet`
+			SET `lifecycle_status` = 'Implementing'
+			WHERE IFNULL(`lifecycle_status`, '') = ''
+			"""
+		)
+
+	for row in legacy_rows:
+		if not frappe.db.has_column("ITM Subnet", "network_address"):
+			break
+		if frappe.db.get_value("ITM Subnet", row.name, "cidr"):
+			continue
+		try:
+			design = design_from_cidr(row.subnet)
+		except (ValueError, TypeError):
+			frappe.log(f"ITM Subnet {row.name}: could not parse legacy CIDR {row.subnet!r}")
+			continue
+
+		frappe.db.set_value(
+			"ITM Subnet",
+			row.name,
+			{
+				"network_address": design["network_address"],
+				"prefix_length": design["prefix_length"],
+				"subnet_mask": design["subnet_mask"],
+				"cidr": design["cidr"],
+				"first_usable": design["first_usable"],
+				"last_usable": design["last_usable"],
+				"broadcast": design["broadcast"],
+				"usable_hosts": design["usable_hosts"],
+				"lifecycle_status": "Implementing",
+			},
+			update_modified=False,
+		)
+
+	# Fill derived fields for rows that already have network/prefix but empty cidr
+	if frappe.db.has_column("ITM Subnet", "network_address"):
+		pending = frappe.db.sql(
+			"""
+			SELECT name, network_address, prefix_length
+			FROM `tabITM Subnet`
+			WHERE IFNULL(network_address, '') != ''
+				AND IFNULL(cidr, '') = ''
+			""",
+			as_dict=True,
+		)
+		for row in pending:
+			try:
+				design = design_from_network_and_prefix(row.network_address, row.prefix_length)
+			except (ValueError, TypeError):
+				continue
+			frappe.db.set_value(
+				"ITM Subnet",
+				row.name,
+				{
+					"network_address": design["network_address"],
+					"prefix_length": design["prefix_length"],
+					"subnet_mask": design["subnet_mask"],
+					"cidr": design["cidr"],
+					"first_usable": design["first_usable"],
+					"last_usable": design["last_usable"],
+					"broadcast": design["broadcast"],
+					"usable_hosts": design["usable_hosts"],
+				},
+				update_modified=False,
+			)
+
+	frappe.db.set_value(
+		"DocType",
+		"ITM Subnet",
+		{
+			"autoname": "hash",
+			"title_field": "cidr",
+			"allow_rename": 0,
+			"show_title_field_in_link": 1,
+		},
+		update_modified=False,
+	)
+
+	frappe.db.delete("DocField", {"parent": "ITM Subnet", "fieldname": "subnet"})
+	frappe.clear_cache(doctype="ITM Subnet")
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesign **ITM Subnet** so the user designs an IPv4 block; the system derives mask/CIDR/usable range and uses a stable document name.

### Locked decisions (this PR)
- IPv4 only
- Landscape-wide overlap + VLAN checks, **warn-only** (stronger when **Running**)
- Stable `hash` name + **CIDR as title**
- VLAN clashes warn landscape-wide

### Changes
- Fields: `network_address`, `prefix_length` → derived `subnet_mask`, `cidr`, first/last usable, broadcast, `usable_hosts`
- `lifecycle_status`: Planned / Implementing / Running / Storage / Obsolete
- Autoname `hash`, `title_field` = `cidr`
- Shared helper `it_management.utils.ipv4`
- Form recalculates design on address/prefix change
- Migrate patch from legacy `subnet` CIDR text
- Unit tests for IPv4 helpers

### Out of scope (later)
- Networking child workspace
- Plan-subnet wizard
- IP free/used inventory UI

### After merge
Run `bench migrate`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

