### PR TITLE
feat: Networking workspace, overview, and plan-subnet wizard

### DIFF
--- a/it_management/hooks.py
+++ b/it_management/hooks.py
@@ -41,7 +41,10 @@ app_include_js = [
 # web_include_js = "/assets/it_management/js/it_management.js"
 
 # include js in page
-page_js = {"it-landscape-graph": "public/js/it_landscape_graph.js"}
+page_js = {
+	"it-landscape-graph": "public/js/it_landscape_graph.js",
+	"it-networking-overview": "public/js/it_networking_overview.js",
+}
 
 # include js in doctype views
 doctype_js = {

--- a/it_management/it_management/page/it_networking_overview/__init__.py
+++ b/it_management/it_management/page/it_networking_overview/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, IT Management contributors

--- a/it_management/it_management/page/it_networking_overview/it_networking_overview.js
+++ b/it_management/it_management/page/it_networking_overview/it_networking_overview.js
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+// For license information, please see license.txt
+
+frappe.pages["it-networking-overview"].on_page_load = function (wrapper) {
+	const page = frappe.ui.make_app_page({
+		parent: wrapper,
+		title: __("Networking"),
+		single_column: true,
+	});
+
+	$(wrapper).find(".layout-main-section").empty().append(`
+		<div class="itm-networking-overview-mount"></div>
+	`);
+
+	const assets = [
+		"/assets/it_management/js/it_networking_overview.js",
+		"/assets/it_management/css/it_networking_overview.css",
+	];
+
+	frappe.require(assets, () => {
+		if (
+			!(
+				window.it_management &&
+				it_management.networking &&
+				it_management.networking.NetworkingOverview
+			)
+		) {
+			frappe.msgprint({
+				title: __("Missing library"),
+				message: __("Networking Overview script did not load."),
+				indicator: "red",
+			});
+			return;
+		}
+
+		const view = new it_management.networking.NetworkingOverview({
+			wrapper: $(wrapper).find(".itm-networking-overview-mount").get(0),
+			page,
+		});
+		view.init();
+	});
+};

--- a/it_management/it_management/page/it_networking_overview/it_networking_overview.json
+++ b/it_management/it_management/page/it_networking_overview/it_networking_overview.json
@@ -1,0 +1,27 @@
+{
+ "content": null,
+ "creation": "2026-07-19 15:40:00.000000",
+ "docstatus": 0,
+ "doctype": "Page",
+ "idx": 0,
+ "modified": "2026-07-19 15:40:00.000000",
+ "modified_by": "Administrator",
+ "module": "IT Management",
+ "name": "it-networking-overview",
+ "owner": "Administrator",
+ "page_name": "it-networking-overview",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Desk User"
+  },
+  {
+   "role": "Support Team"
+  }
+ ],
+ "standard": "Yes",
+ "system_page": 0,
+ "title": "Networking Overview"
+}

--- a/it_management/it_management/utils/networking.py
+++ b/it_management/it_management/utils/networking.py
@@ -1,0 +1,326 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""Networking overview and plan-subnet wizard helpers."""
+
+from __future__ import unicode_literals
+
+import ipaddress
+
+import frappe
+from frappe import _
+
+from it_management.it_management.utils.ipv4 import (
+	design_from_network_and_prefix,
+	ranges_overlap,
+)
+
+# Suggestion packs for the plan-subnet wizard (IPv4 only)
+PURPOSE_PROFILES = {
+	"Corporate": {
+		"label": "Corporate",
+		"description": "Trusted internal LAN for workstations and servers.",
+		"preferred_prefix": 24,
+		"growth_factor": 1.3,
+		"vlan_hint": 10,
+		"search_bases": ["10.0.0.0/16", "10.10.0.0/16", "172.16.0.0/16"],
+		"notes": "Prefer RFC1918 private space; keep management hosts reachable.",
+	},
+	"Guest Wi-Fi": {
+		"label": "Guest Wi-Fi",
+		"description": "Isolated wireless access for visitors.",
+		"preferred_prefix": 23,
+		"growth_factor": 1.5,
+		"vlan_hint": 40,
+		"search_bases": ["10.40.0.0/16", "10.50.0.0/16", "192.168.40.0/16"],
+		"notes": "Isolate from corporate; limited DHCP lease times recommended.",
+	},
+	"DMZ": {
+		"label": "DMZ",
+		"description": "Public-facing or semi-trusted services.",
+		"preferred_prefix": 24,
+		"growth_factor": 1.2,
+		"vlan_hint": 30,
+		"search_bases": ["10.30.0.0/16", "172.30.0.0/16"],
+		"notes": "Tight firewall rules; minimal host count; no client DHCP pool by default.",
+	},
+	"Management": {
+		"label": "Management",
+		"description": "Out-of-band / infrastructure management network.",
+		"preferred_prefix": 24,
+		"growth_factor": 1.2,
+		"vlan_hint": 99,
+		"search_bases": ["10.99.0.0/16", "172.31.0.0/16"],
+		"notes": "Restrict access to admins and controllers only.",
+	},
+	"IoT": {
+		"label": "IoT",
+		"description": "Sensors, printers, and other constrained devices.",
+		"preferred_prefix": 22,
+		"growth_factor": 1.4,
+		"vlan_hint": 60,
+		"search_bases": ["10.60.0.0/16", "10.70.0.0/16"],
+		"notes": "Expect many small clients; segment from corporate data.",
+	},
+}
+
+
+def _prefix_for_clients(expected_clients, growth_factor, preferred_prefix):
+	"""Pick a prefix that fits expected clients with growth headroom."""
+	try:
+		clients = max(int(expected_clients or 0), 1)
+	except (TypeError, ValueError):
+		clients = 1
+	needed = int(clients * float(growth_factor or 1.3)) + 2  # network + broadcast
+	# usable hosts for prefix p is 2^(32-p) - 2 for p < 31
+	for prefix in range(preferred_prefix, 8, -1):
+		usable = (2 ** (32 - prefix)) - 2 if prefix < 31 else 2 ** (32 - prefix)
+		if usable >= needed:
+			return prefix
+	return 16
+
+
+def _landscape_ranges(landscape):
+	rows = frappe.get_all(
+		"ITM Subnet",
+		filters={"itm_landscape": landscape, "network_address": ["!=", ""]},
+		fields=["name", "cidr", "network_address", "prefix_length", "lifecycle_status"],
+	)
+	ranges = []
+	for row in rows:
+		try:
+			design = design_from_network_and_prefix(row.network_address, row.prefix_length)
+		except (ValueError, TypeError):
+			continue
+		ranges.append(
+			{
+				"name": row.name,
+				"cidr": design["cidr"],
+				"lifecycle_status": row.lifecycle_status,
+				"network_int": design["network_int"],
+				"broadcast_int": design["broadcast_int"],
+			}
+		)
+	return ranges
+
+
+def _find_free_block(landscape, prefix_length, search_bases):
+	existing = _landscape_ranges(landscape)
+	for base in search_bases:
+		try:
+			parent = ipaddress.ip_network(base, strict=False)
+		except ValueError:
+			continue
+		if prefix_length < parent.prefixlen:
+			continue
+		for subnet in parent.subnets(new_prefix=prefix_length):
+			start = int(subnet.network_address)
+			end = int(subnet.broadcast_address)
+			conflict = False
+			for other in existing:
+				if ranges_overlap(start, end, other["network_int"], other["broadcast_int"]):
+					conflict = True
+					break
+			if not conflict:
+				return design_from_network_and_prefix(str(subnet.network_address), prefix_length)
+	# Fallback: try 10.x sequentially
+	for second_octet in range(0, 256):
+		try:
+			design = design_from_network_and_prefix(f"10.{second_octet}.0.0", prefix_length)
+		except (ValueError, TypeError):
+			continue
+		conflict = any(
+			ranges_overlap(
+				design["network_int"],
+				design["broadcast_int"],
+				other["network_int"],
+				other["broadcast_int"],
+			)
+			for other in existing
+		)
+		if not conflict:
+			return design
+	frappe.throw(_("Could not find a free IPv4 block in this landscape."), title=_("No Free Space"))
+
+
+def _subnet_utilization(subnet_name, usable_hosts):
+	used = frappe.db.count("ITM IP Address", {"itm_subnet": subnet_name})
+	usable = int(usable_hosts or 0)
+	free = max(usable - used, 0)
+	return {"used": used, "reserved": 0, "free": free, "usable": usable}
+
+
+@frappe.whitelist()
+def get_purpose_profiles():
+	"""Return wizard suggestion packs."""
+	return [
+		{
+			"name": key,
+			"label": _(profile["label"]),
+			"description": _(profile["description"]),
+			"preferred_prefix": profile["preferred_prefix"],
+			"vlan_hint": profile["vlan_hint"],
+			"notes": _(profile["notes"]),
+		}
+		for key, profile in PURPOSE_PROFILES.items()
+	]
+
+
+@frappe.whitelist()
+def get_networking_overview(itm_landscape=None):
+	"""LAN-centric utilization tree for the Networking overview page."""
+	if not itm_landscape:
+		frappe.throw(_("Landscape is required."), title=_("Missing Landscape"))
+
+	lans = frappe.get_all(
+		"ITM Local Area Network",
+		filters={"itm_landscape": itm_landscape},
+		fields=["name", "title", "itm_location", "note"],
+		order_by="title asc",
+	)
+
+	result = []
+	for lan in lans:
+		subnets = frappe.get_all(
+			"ITM Subnet",
+			filters={"itm_local_area_network": lan.name},
+			fields=[
+				"name",
+				"cidr",
+				"network_address",
+				"prefix_length",
+				"usable_hosts",
+				"lifecycle_status",
+				"vlan_tag",
+			],
+			order_by="cidr asc",
+		)
+		subnet_rows = []
+		for subnet in subnets:
+			util = _subnet_utilization(subnet.name, subnet.usable_hosts)
+			subnet_rows.append(
+				{
+					"name": subnet.name,
+					"cidr": subnet.cidr,
+					"lifecycle_status": subnet.lifecycle_status,
+					"vlan_tag": subnet.vlan_tag,
+					**util,
+				}
+			)
+		result.append(
+			{
+				"name": lan.name,
+				"title": lan.title or lan.name,
+				"itm_location": lan.itm_location,
+				"note": lan.note,
+				"subnets": subnet_rows,
+			}
+		)
+	return {"itm_landscape": itm_landscape, "lans": result}
+
+
+@frappe.whitelist()
+def suggest_subnet_design(
+	itm_landscape=None,
+	purpose_profile=None,
+	expected_clients=None,
+	prefix_length=None,
+):
+	"""Suggest a free IPv4 design for the wizard address step."""
+	if not itm_landscape:
+		frappe.throw(_("Landscape is required."), title=_("Missing Landscape"))
+
+	profile = PURPOSE_PROFILES.get(purpose_profile) or PURPOSE_PROFILES["Corporate"]
+	if prefix_length in (None, ""):
+		prefix_length = _prefix_for_clients(
+			expected_clients, profile["growth_factor"], profile["preferred_prefix"]
+		)
+	else:
+		prefix_length = int(prefix_length)
+
+	design = _find_free_block(itm_landscape, prefix_length, profile["search_bases"])
+	conflicts = []
+	for other in _landscape_ranges(itm_landscape):
+		if ranges_overlap(
+			design["network_int"],
+			design["broadcast_int"],
+			other["network_int"],
+			other["broadcast_int"],
+		):
+			conflicts.append(other)
+
+	return {
+		"purpose_profile": purpose_profile or "Corporate",
+		"profile_notes": _(profile["notes"]),
+		"vlan_hint": profile["vlan_hint"],
+		"design": {k: v for k, v in design.items() if not k.endswith("_int")},
+		"conflicts": conflicts,
+	}
+
+
+@frappe.whitelist()
+def quick_create_host_item(title=None, itm_landscape=None, itm_location=None):
+	"""Minimal Host Item create for wizard infra step."""
+	if not title:
+		frappe.throw(_("Host title is required."), title=_("Missing Title"))
+	if not itm_landscape:
+		frappe.throw(_("Landscape is required."), title=_("Missing Landscape"))
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "ITM Host Item",
+			"title": title,
+			"itm_landscape": itm_landscape,
+			"itm_location": itm_location,
+			"lifecycle_status": "Implementing",
+			"health_status": "Unknown",
+			"deployment": "Physical",
+		}
+	)
+	doc.insert()
+	return {"name": doc.name, "title": doc.title}
+
+
+@frappe.whitelist()
+def create_subnet_from_wizard(values=None):
+	"""Create an ITM Subnet (Implementing) from wizard review payload."""
+	if isinstance(values, str):
+		values = frappe.parse_json(values)
+	values = frappe._dict(values or {})
+
+	required = ("itm_local_area_network", "network_address", "prefix_length")
+	for key in required:
+		if not values.get(key):
+			frappe.throw(_("{0} is required.").format(key), title=_("Missing Value"))
+
+	lan = frappe.db.get_value(
+		"ITM Local Area Network",
+		values.itm_local_area_network,
+		["name", "itm_landscape", "itm_location"],
+		as_dict=True,
+	)
+	if not lan:
+		frappe.throw(_("Local Area Network was not found."), title=_("Invalid LAN"))
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "ITM Subnet",
+			"network_address": values.network_address,
+			"prefix_length": values.prefix_length,
+			"itm_local_area_network": lan.name,
+			"itm_landscape": lan.itm_landscape,
+			"itm_location": values.get("itm_location") or lan.itm_location,
+			"lifecycle_status": values.get("lifecycle_status") or "Implementing",
+			"vlan_tag": values.get("vlan_tag"),
+			"gateway": values.get("gateway"),
+			"dhcp": values.get("dhcp"),
+			"dns_1": values.get("dns_1"),
+			"dns_2": values.get("dns_2"),
+			"ntp_1": values.get("ntp_1"),
+			"ntp_2": values.get("ntp_2"),
+			"note": values.get("note"),
+			"wireless": values.get("wireless"),
+		}
+	)
+	doc.insert()
+	return {"name": doc.name, "cidr": doc.cidr, "lifecycle_status": doc.lifecycle_status}

--- a/it_management/it_management/utils/test_networking.py
+++ b/it_management/it_management/utils/test_networking.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, IT Management contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+import unittest
+
+try:
+	import frappe  # noqa: F401
+except ImportError:
+	frappe = None
+
+
+@unittest.skipIf(frappe is None, "frappe not installed")
+class TestNetworkingHelpers(unittest.TestCase):
+	def test_purpose_profiles_complete(self):
+		from it_management.it_management.utils.networking import PURPOSE_PROFILES
+
+		expected = {"Corporate", "Guest Wi-Fi", "DMZ", "Management", "IoT"}
+		self.assertEqual(set(PURPOSE_PROFILES), expected)
+		for profile in PURPOSE_PROFILES.values():
+			self.assertIn("preferred_prefix", profile)
+			self.assertIn("search_bases", profile)
+			self.assertIn("vlan_hint", profile)
+
+	def test_prefix_grows_with_clients(self):
+		from it_management.it_management.utils.networking import _prefix_for_clients
+
+		small = _prefix_for_clients(20, 1.3, 24)
+		large = _prefix_for_clients(400, 1.5, 23)
+		self.assertGreaterEqual(small, large)
+
+
+class TestPrefixHelperStandalone(unittest.TestCase):
+	"""Mirror of _prefix_for_clients for environments without frappe."""
+
+	def test_prefix_logic(self):
+		def prefix_for_clients(expected_clients, growth_factor, preferred_prefix):
+			clients = max(int(expected_clients or 0), 1)
+			needed = int(clients * float(growth_factor or 1.3)) + 2
+			for prefix in range(preferred_prefix, 8, -1):
+				usable = (2 ** (32 - prefix)) - 2 if prefix < 31 else 2 ** (32 - prefix)
+				if usable >= needed:
+					return prefix
+			return 16
+
+		self.assertEqual(prefix_for_clients(20, 1.3, 24), 24)
+		self.assertLessEqual(prefix_for_clients(400, 1.5, 23), 23)

--- a/it_management/it_management/workspace/it_management/it_management.json
+++ b/it_management/it_management/workspace/it_management/it_management.json
@@ -1,7 +1,7 @@
 {
  "app": "it_management",
  "charts": [],
- "content": "[{\"id\": \"EkdyV3N5Ie\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">IT Management</span>\", \"col\": 12}}, {\"id\": \"rwNPVL-p3-\", \"type\": \"paragraph\", \"data\": {\"text\": \"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\", \"col\": 12}}, {\"id\": \"lVIHnh6pht\", \"type\": \"paragraph\", \"data\": {\"text\": \"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\", \"col\": 12}}, {\"id\": \"itmCfgHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"pferI51Txs\", \"type\": \"card\", \"data\": {\"card_name\": \"Configuration\", \"col\": 4}}, {\"id\": \"itmNetHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"itmNetPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Networking for each ITM Landscape: locations, LANs, subnets, IP addresses, host NICs, wall sockets, and host domains.\", \"col\": 12}}, {\"id\": \"itmNetCard1\", \"type\": \"card\", \"data\": {\"card_name\": \"Networking\", \"col\": 6}}]",
+ "content": "[{\"id\": \"EkdyV3N5Ie\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">IT Management</span>\", \"col\": 12}}, {\"id\": \"rwNPVL-p3-\", \"type\": \"paragraph\", \"data\": {\"text\": \"Welcome to the IT Management App. This app is built on Frappe and can be run without using ERPNext. If desired it can be activated for ERPNext through the settings. Each DocType created for the IT Management app carries the prefix ITM to avoid name duplicates and to quickly identity them as belonging to the IT Management app.\", \"col\": 12}}, {\"id\": \"lVIHnh6pht\", \"type\": \"paragraph\", \"data\": {\"text\": \"Your IT overview starts with the ITM Landscape. An ITM Landscape is linked to most other DocTypes in this app and will help you navigate all the different DocTypes available to your ITM Landscapes.\", \"col\": 12}}, {\"id\": \"itmCfgHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Configuration</span>\", \"col\": 12}}, {\"id\": \"pferI51Txs\", \"type\": \"card\", \"data\": {\"card_name\": \"Configuration\", \"col\": 4}}, {\"id\": \"itmNetHdr1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"itmNetPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Open the Networking workspace for LAN utilization, subnet planning, and network DocTypes.\", \"col\": 12}}, {\"id\": \"itmNetShort1\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Networking\", \"col\": 4}}, {\"id\": \"itmNetShort2\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Networking Overview\", \"col\": 4}}]",
  "creation": "2024-01-16 04:51:02.486516",
  "custom_blocks": [],
  "docstatus": 0,
@@ -56,103 +56,33 @@
    "type": "Card Break",
    "label": "Networking",
    "link_type": "DocType",
-   "link_count": 9,
+   "link_count": 2,
    "hidden": 0,
    "is_query_report": 0,
    "onboard": 0
   },
   {
    "type": "Link",
-   "label": "ITM Landscape",
-   "link_to": "ITM Landscape",
-   "link_type": "DocType",
+   "label": "Networking",
+   "link_to": "Networking",
+   "link_type": "Workspace",
    "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
-   "onboard": 0
+   "onboard": 1
   },
   {
    "type": "Link",
-   "label": "ITM Location",
-   "link_to": "ITM Location",
-   "link_type": "DocType",
+   "label": "Networking Overview",
+   "link_to": "it-networking-overview",
+   "link_type": "Page",
    "link_count": 0,
    "hidden": 0,
    "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Host Item",
-   "link_to": "ITM Host Item",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Local Area Network",
-   "link_to": "ITM Local Area Network",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Subnet",
-   "link_to": "ITM Subnet",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM IP Address",
-   "link_to": "ITM IP Address",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Network Interface Controller",
-   "link_to": "ITM Network Interface Controller",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Socket",
-   "link_to": "ITM Socket",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
-  },
-  {
-   "type": "Link",
-   "label": "ITM Host Domain",
-   "link_to": "ITM Host Domain",
-   "link_type": "DocType",
-   "link_count": 0,
-   "hidden": 0,
-   "is_query_report": 0,
-   "onboard": 0
+   "onboard": 1
   }
  ],
- "modified": "2026-07-18 23:55:00.000000",
+ "modified": "2026-07-19 15:45:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",
@@ -163,7 +93,22 @@
  "quick_lists": [],
  "roles": [],
  "sequence_id": 39.0,
- "shortcuts": [],
+ "shortcuts": [
+  {
+   "color": "Blue",
+   "doc_view": "",
+   "label": "Networking",
+   "type": "URL",
+   "url": "/app/networking"
+  },
+  {
+   "color": "Blue",
+   "doc_view": "",
+   "label": "Networking Overview",
+   "link_to": "it-networking-overview",
+   "type": "Page"
+  }
+ ],
  "title": "IT Management",
  "type": "Workspace"
 }

--- a/it_management/it_management/workspace/networking/networking.json
+++ b/it_management/it_management/workspace/networking/networking.json
@@ -1,0 +1,152 @@
+{
+ "app": "it_management",
+ "charts": [],
+ "content": "[{\"id\": \"netHero1\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h4\\\">Networking</span>\", \"col\": 12}}, {\"id\": \"netPara1\", \"type\": \"paragraph\", \"data\": {\"text\": \"Plan and review LANs, subnets, and IP space for each ITM Landscape. Open the overview to see utilization and start the subnet planning wizard.\", \"col\": 12}}, {\"id\": \"netShort1\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"Networking Overview\", \"col\": 4}}, {\"id\": \"netShort2\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"ITM Local Area Network\", \"col\": 4}}, {\"id\": \"netShort3\", \"type\": \"shortcut\", \"data\": {\"shortcut_name\": \"ITM Subnet\", \"col\": 4}}, {\"id\": \"netHdrDocs\", \"type\": \"header\", \"data\": {\"text\": \"<span class=\\\"h5\\\">Network DocTypes</span>\", \"col\": 12}}, {\"id\": \"netCard1\", \"type\": \"card\", \"data\": {\"card_name\": \"Network DocTypes\", \"col\": 6}}]",
+ "creation": "2026-07-19 15:40:00.000000",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "globe",
+ "idx": 0,
+ "is_hidden": 0,
+ "label": "Networking",
+ "links": [
+  {
+   "type": "Card Break",
+   "label": "Network DocTypes",
+   "link_type": "DocType",
+   "link_count": 8,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "Networking Overview",
+   "link_to": "it-networking-overview",
+   "link_type": "Page",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 1
+  },
+  {
+   "type": "Link",
+   "label": "ITM Local Area Network",
+   "link_to": "ITM Local Area Network",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Subnet",
+   "link_to": "ITM Subnet",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM IP Address",
+   "link_to": "ITM IP Address",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Network Interface Controller",
+   "link_to": "ITM Network Interface Controller",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Socket",
+   "link_to": "ITM Socket",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Host Domain",
+   "link_to": "ITM Host Domain",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Location",
+   "link_to": "ITM Location",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  },
+  {
+   "type": "Link",
+   "label": "ITM Host Item",
+   "link_to": "ITM Host Item",
+   "link_type": "DocType",
+   "link_count": 0,
+   "hidden": 0,
+   "is_query_report": 0,
+   "onboard": 0
+  }
+ ],
+ "modified": "2026-07-19 15:40:00.000000",
+ "modified_by": "Administrator",
+ "module": "IT Management",
+ "name": "Networking",
+ "number_cards": [],
+ "owner": "Administrator",
+ "parent_page": "IT Management",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 40.0,
+ "shortcuts": [
+  {
+   "color": "Blue",
+   "doc_view": "",
+   "label": "Networking Overview",
+   "link_to": "it-networking-overview",
+   "type": "Page"
+  },
+  {
+   "color": "Blue",
+   "doc_view": "List",
+   "label": "ITM Local Area Network",
+   "link_to": "ITM Local Area Network",
+   "type": "DocType"
+  },
+  {
+   "color": "Blue",
+   "doc_view": "List",
+   "label": "ITM Subnet",
+   "link_to": "ITM Subnet",
+   "type": "DocType"
+  }
+ ],
+ "title": "Networking",
+ "type": "Workspace"
+}

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -19,3 +19,4 @@ it_management.patches.0_4.add_address_map_geo_fields
 it_management.patches.0_4.rename_itm_location_nestedset_fields
 it_management.patches.0_4.migrate_itm_subnet_lan_link
 it_management.patches.0_4.migrate_itm_subnet_address_model
+it_management.patches.0_4.setup_itm_networking_workspace

--- a/it_management/patches/0_4/setup_itm_networking_workspace.py
+++ b/it_management/patches/0_4/setup_itm_networking_workspace.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""Ensure Networking Overview page and Networking child workspace exist."""
+
+import frappe
+
+PAGE_NAME = "it-networking-overview"
+
+
+def execute():
+	_ensure_page()
+	frappe.reload_doc("IT Management", "workspace", "networking", force=True)
+	frappe.reload_doc("IT Management", "workspace", "it_management", force=True)
+	frappe.clear_cache()
+	frappe.db.commit()
+
+
+def _ensure_page():
+	page_values = {
+		"page_name": PAGE_NAME,
+		"title": "Networking Overview",
+		"module": "IT Management",
+		"standard": "Yes",
+	}
+
+	if frappe.db.exists("Page", PAGE_NAME):
+		page = frappe.get_doc("Page", PAGE_NAME)
+		changed = False
+		for fieldname, value in page_values.items():
+			if page.get(fieldname) != value:
+				page.set(fieldname, value)
+				changed = True
+		if not page.roles:
+			page.append("roles", {"role": "System Manager"})
+			page.append("roles", {"role": "Desk User"})
+			page.append("roles", {"role": "Support Team"})
+			changed = True
+		if changed:
+			page.flags.ignore_validate = True
+			page.save(ignore_permissions=True)
+		return
+
+	page = frappe.get_doc(
+		{
+			"doctype": "Page",
+			**page_values,
+			"roles": [
+				{"role": "System Manager"},
+				{"role": "Desk User"},
+				{"role": "Support Team"},
+			],
+		}
+	)
+	page.flags.ignore_validate = True
+	page.insert(ignore_permissions=True)

--- a/it_management/public/css/it_networking_overview.css
+++ b/it_management/public/css/it_networking_overview.css
@@ -1,0 +1,186 @@
+/* Networking overview + plan-subnet wizard */
+
+.itm-net {
+	--itm-net-ink: #1c2b33;
+	--itm-net-muted: #5a6b73;
+	--itm-net-line: #d5e0e4;
+	--itm-net-accent: #0f766e;
+	--itm-net-accent-soft: #ccfbf1;
+	--itm-net-warn: #b45309;
+	--itm-net-used: #0f766e;
+	--itm-net-free: #94a3b8;
+	max-width: 1100px;
+	margin: 0 auto;
+	padding: 0.5rem 0 2rem;
+	color: var(--itm-net-ink);
+}
+
+.itm-net__hero {
+	margin-bottom: 1.5rem;
+}
+
+.itm-net__brand {
+	font-size: 1.75rem;
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	margin: 0;
+}
+
+.itm-net__lede {
+	margin: 0.35rem 0 0;
+	color: var(--itm-net-muted);
+	max-width: 40rem;
+}
+
+.itm-net__toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	align-items: flex-end;
+	margin-bottom: 1.25rem;
+}
+
+.itm-net__toolbar .frappe-control {
+	min-width: 220px;
+	margin-bottom: 0;
+}
+
+.itm-net__lan {
+	border-top: 1px solid var(--itm-net-line);
+	padding: 1rem 0 1.25rem;
+}
+
+.itm-net__lan-title {
+	display: flex;
+	justify-content: space-between;
+	align-items: baseline;
+	gap: 1rem;
+	margin-bottom: 0.75rem;
+}
+
+.itm-net__lan-title h3 {
+	margin: 0;
+	font-size: 1.1rem;
+}
+
+.itm-net__lan-meta {
+	color: var(--itm-net-muted);
+	font-size: 0.85rem;
+}
+
+.itm-net__subnet {
+	margin: 0.65rem 0 0.9rem;
+}
+
+.itm-net__subnet-head {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	gap: 0.5rem;
+	margin-bottom: 0.35rem;
+	font-size: 0.92rem;
+}
+
+.itm-net__subnet-head a {
+	font-weight: 600;
+}
+
+.itm-net__status {
+	display: inline-block;
+	font-size: 0.75rem;
+	color: var(--itm-net-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.itm-net__bar {
+	display: flex;
+	height: 0.65rem;
+	border-radius: 999px;
+	overflow: hidden;
+	background: #e8eef0;
+}
+
+.itm-net__bar-used {
+	background: var(--itm-net-used);
+}
+
+.itm-net__bar-free {
+	background: var(--itm-net-free);
+}
+
+.itm-net__counts {
+	margin-top: 0.25rem;
+	font-size: 0.8rem;
+	color: var(--itm-net-muted);
+}
+
+.itm-net__empty {
+	padding: 1.5rem 0;
+	color: var(--itm-net-muted);
+}
+
+.itm-net-wizard .modal-dialog {
+	max-width: 720px;
+}
+
+.itm-net-wizard__steps {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.4rem;
+	margin-bottom: 1rem;
+	padding-bottom: 0.75rem;
+	border-bottom: 1px solid var(--itm-net-line);
+}
+
+.itm-net-wizard__step {
+	font-size: 0.75rem;
+	padding: 0.2rem 0.55rem;
+	border-radius: 999px;
+	color: var(--itm-net-muted);
+	background: #f1f5f6;
+}
+
+.itm-net-wizard__step.is-active {
+	background: var(--itm-net-accent-soft);
+	color: var(--itm-net-accent);
+	font-weight: 600;
+}
+
+.itm-net-wizard__step.is-done {
+	color: var(--itm-net-ink);
+}
+
+.itm-net-wizard__hint {
+	font-size: 0.85rem;
+	color: var(--itm-net-muted);
+	margin: 0 0 0.75rem;
+}
+
+.itm-net-wizard__warn {
+	border-left: 3px solid var(--itm-net-warn);
+	padding: 0.5rem 0.75rem;
+	margin: 0.5rem 0 0.75rem;
+	background: #fffbeb;
+	color: #78350f;
+	font-size: 0.85rem;
+}
+
+.itm-net-wizard__design {
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 0.9rem;
+	line-height: 1.5;
+	margin: 0.5rem 0 0;
+}
+
+.itm-net-wizard__role-row {
+	display: flex;
+	gap: 0.5rem;
+	align-items: flex-end;
+	margin-bottom: 0.35rem;
+}
+
+.itm-net-wizard__role-row .frappe-control {
+	flex: 1;
+	margin-bottom: 0;
+}

--- a/it_management/public/js/it_networking_overview.js
+++ b/it_management/public/js/it_networking_overview.js
@@ -1,0 +1,654 @@
+// Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+// For license information, please see license.txt
+
+frappe.provide("it_management.networking");
+
+it_management.networking.NetworkingOverview = class NetworkingOverview {
+	constructor({ wrapper, page }) {
+		this.$wrapper = $(wrapper);
+		this.page = page;
+		this.landscape = null;
+		this.profiles = [];
+	}
+
+	init() {
+		this.render_shell();
+		this.bind_actions();
+		this.load_profiles();
+	}
+
+	render_shell() {
+		this.$wrapper.html(`
+			<div class="itm-net">
+				<div class="itm-net__hero">
+					<p class="itm-net__brand">${__("Networking")}</p>
+					<p class="itm-net__lede">${__(
+						"Sites, LANs, subnets, and IP space — plan new networks and see what is still free."
+					)}</p>
+				</div>
+				<div class="itm-net__toolbar">
+					<div class="itm-net__landscape-field"></div>
+					<button class="btn btn-primary btn-sm itm-net__plan-btn" type="button">
+						${__("Plan new subnet")}
+					</button>
+				</div>
+				<div class="itm-net__body">
+					<div class="itm-net__empty text-muted">${__("Select a Landscape to load LANs and subnets.")}</div>
+				</div>
+			</div>
+		`);
+
+		this.landscape_control = frappe.ui.form.make_control({
+			parent: this.$wrapper.find(".itm-net__landscape-field"),
+			df: {
+				fieldtype: "Link",
+				options: "ITM Landscape",
+				label: __("Landscape"),
+				fieldname: "itm_landscape",
+				reqd: 1,
+				change: () => {
+					this.landscape = this.landscape_control.get_value();
+					this.refresh_overview();
+				},
+			},
+			render_input: true,
+		});
+	}
+
+	bind_actions() {
+		this.$wrapper.on("click", ".itm-net__plan-btn", () => {
+			if (!this.landscape) {
+				frappe.msgprint(__("Select a Landscape first."));
+				return;
+			}
+			new it_management.networking.PlanSubnetWizard({
+				landscape: this.landscape,
+				profiles: this.profiles,
+				on_created: () => this.refresh_overview(),
+			}).show();
+		});
+	}
+
+	load_profiles() {
+		frappe.call({
+			method: "it_management.it_management.utils.networking.get_purpose_profiles",
+			callback: (r) => {
+				this.profiles = r.message || [];
+			},
+		});
+	}
+
+	refresh_overview() {
+		const $body = this.$wrapper.find(".itm-net__body");
+		if (!this.landscape) {
+			$body.html(
+				`<div class="itm-net__empty">${__("Select a Landscape to load LANs and subnets.")}</div>`
+			);
+			return;
+		}
+
+		$body.html(`<div class="text-muted">${__("Loading…")}</div>`);
+		frappe.call({
+			method: "it_management.it_management.utils.networking.get_networking_overview",
+			args: { itm_landscape: this.landscape },
+			callback: (r) => {
+				const lans = (r.message && r.message.lans) || [];
+				if (!lans.length) {
+					$body.html(
+						`<div class="itm-net__empty">${__(
+							"No Local Area Networks in this Landscape yet. Create a LAN, then plan a subnet."
+						)}</div>`
+					);
+					return;
+				}
+				$body.html(lans.map((lan) => this.render_lan(lan)).join(""));
+			},
+		});
+	}
+
+	render_lan(lan) {
+		const subnets = lan.subnets || [];
+		const subnet_html = subnets.length
+			? subnets.map((s) => this.render_subnet(s)).join("")
+			: `<div class="itm-net__empty">${__("No subnets on this LAN yet.")}</div>`;
+
+		return `
+			<section class="itm-net__lan">
+				<div class="itm-net__lan-title">
+					<h3>
+						<a href="/app/itm-local-area-network/${encodeURIComponent(lan.name)}">${frappe.utils.escape_html(
+							lan.title
+						)}</a>
+					</h3>
+					<span class="itm-net__lan-meta">${
+						lan.itm_location
+							? frappe.utils.escape_html(lan.itm_location)
+							: __("No location")
+					} · ${__(
+						subnets.length === 1 ? "{0} subnet" : "{0} subnets",
+						[subnets.length]
+					)}</span>
+				</div>
+				${subnet_html}
+			</section>
+		`;
+	}
+
+	render_subnet(s) {
+		const usable = s.usable || 0;
+		const used = s.used || 0;
+		const free = s.free || 0;
+		const used_pct = usable ? Math.min(100, Math.round((used / usable) * 100)) : 0;
+		const free_pct = Math.max(0, 100 - used_pct);
+		return `
+			<div class="itm-net__subnet">
+				<div class="itm-net__subnet-head">
+					<span>
+						<a href="/app/itm-subnet/${encodeURIComponent(s.name)}">${frappe.utils.escape_html(
+							s.cidr || s.name
+						)}</a>
+						<span class="itm-net__status">${frappe.utils.escape_html(s.lifecycle_status || "")}</span>
+						${
+							s.vlan_tag != null && s.vlan_tag !== ""
+								? `<span class="itm-net__status">VLAN ${frappe.utils.escape_html(
+										String(s.vlan_tag)
+								  )}</span>`
+								: ""
+						}
+					</span>
+				</div>
+				<div class="itm-net__bar" title="${used} used / ${free} free">
+					<div class="itm-net__bar-used" style="width:${used_pct}%"></div>
+					<div class="itm-net__bar-free" style="width:${free_pct}%"></div>
+				</div>
+				<div class="itm-net__counts">${__("{0} used · {1} free · {2} usable", [
+					used,
+					free,
+					usable,
+				])}</div>
+			</div>
+		`;
+	}
+};
+
+it_management.networking.PlanSubnetWizard = class PlanSubnetWizard {
+	constructor({ landscape, profiles, on_created }) {
+		this.landscape = landscape;
+		this.profiles = profiles || [];
+		this.on_created = on_created;
+		this.step = 0;
+		this.steps = [
+			__("Purpose"),
+			__("Size"),
+			__("Address"),
+			__("Infrastructure"),
+			__("Review"),
+		];
+		this.state = {
+			purpose_profile: "Corporate",
+			expected_clients: 50,
+			prefix_length: null,
+			itm_local_area_network: null,
+			itm_location: null,
+			vlan_tag: null,
+			network_address: null,
+			design: null,
+			conflicts: [],
+			profile_notes: "",
+			gateway: null,
+			dhcp: null,
+			dns_1: null,
+			dns_2: null,
+			ntp_1: null,
+			ntp_2: null,
+			note: "",
+		};
+	}
+
+	show() {
+		this.dialog = new frappe.ui.Dialog({
+			title: __("Plan a subnet"),
+			size: "large",
+			fields: [{ fieldtype: "HTML", fieldname: "body" }],
+			primary_action_label: __("Next"),
+			primary_action: () => this.next(),
+			secondary_action_label: __("Back"),
+			secondary_action: () => this.back(),
+		});
+		this.dialog.$wrapper.addClass("itm-net-wizard");
+		this.dialog.show();
+		this.render_step();
+	}
+
+	set_footer() {
+		const $primary = this.dialog.get_primary_btn();
+		if (this.step === this.steps.length - 1) {
+			$primary.text(__("Create as Implementing"));
+		} else {
+			$primary.text(__("Next"));
+		}
+		const $secondary =
+			(this.dialog.get_secondary_btn && this.dialog.get_secondary_btn()) ||
+			this.dialog.$wrapper.find(".btn-modal-secondary");
+		if (!$secondary || !$secondary.length) {
+			return;
+		}
+		if (this.step === 0) {
+			$secondary.hide();
+		} else {
+			$secondary.show().text(__("Back"));
+		}
+	}
+
+	back() {
+		if (this.step > 0) {
+			this.step -= 1;
+			this.render_step();
+		}
+	}
+
+	async next() {
+		const ok = await this.collect_step();
+		if (!ok) {
+			return;
+		}
+		if (this.step < this.steps.length - 1) {
+			this.step += 1;
+			if (this.step === 2) {
+				await this.load_suggestion();
+			}
+			this.render_step();
+			return;
+		}
+		await this.create();
+	}
+
+	async collect_step() {
+		const $body = $(this.dialog.fields_dict.body.wrapper);
+		if (this.step === 0) {
+			const purpose = $body.find("[name=purpose_profile]:checked").val();
+			if (!purpose) {
+				frappe.msgprint(__("Choose a purpose profile."));
+				return false;
+			}
+			this.state.purpose_profile = purpose;
+			const lan = this.lan_control && this.lan_control.get_value();
+			if (!lan) {
+				frappe.msgprint(__("Select a Local Area Network."));
+				return false;
+			}
+			this.state.itm_local_area_network = lan;
+			return true;
+		}
+		if (this.step === 1) {
+			const clients = cint($body.find("[name=expected_clients]").val());
+			if (!clients || clients < 1) {
+				frappe.msgprint(__("Enter expected clients."));
+				return false;
+			}
+			this.state.expected_clients = clients;
+			const prefix = $body.find("[name=prefix_length]").val();
+			this.state.prefix_length = prefix === "" ? null : cint(prefix);
+			return true;
+		}
+		if (this.step === 2) {
+			const network = ($body.find("[name=network_address]").val() || "").trim();
+			const prefix = cint($body.find("[name=prefix_length]").val());
+			const vlan = $body.find("[name=vlan_tag]").val();
+			if (!network || !prefix) {
+				frappe.msgprint(__("Network address and prefix are required."));
+				return false;
+			}
+			this.state.network_address = network;
+			this.state.prefix_length = prefix;
+			this.state.vlan_tag = vlan === "" ? null : cint(vlan);
+			await this.recalculate_design();
+			return !!this.state.design;
+		}
+		if (this.step === 3) {
+			["gateway", "dhcp", "dns_1", "dns_2", "ntp_1", "ntp_2"].forEach((field) => {
+				const ctrl = this.role_controls && this.role_controls[field];
+				this.state[field] = ctrl ? ctrl.get_value() : null;
+			});
+			return true;
+		}
+		return true;
+	}
+
+	async load_suggestion() {
+		const r = await frappe.call({
+			method: "it_management.it_management.utils.networking.suggest_subnet_design",
+			args: {
+				itm_landscape: this.landscape,
+				purpose_profile: this.state.purpose_profile,
+				expected_clients: this.state.expected_clients,
+				prefix_length: this.state.prefix_length,
+			},
+		});
+		const msg = r.message || {};
+		this.state.design = msg.design;
+		this.state.conflicts = msg.conflicts || [];
+		this.state.profile_notes = msg.profile_notes || "";
+		this.state.vlan_tag = this.state.vlan_tag != null ? this.state.vlan_tag : msg.vlan_hint;
+		if (msg.design) {
+			this.state.network_address = msg.design.network_address;
+			this.state.prefix_length = msg.design.prefix_length;
+		}
+	}
+
+	async recalculate_design() {
+		try {
+			const r = await frappe.call({
+				method:
+					"it_management.it_management.doctype.itm_subnet.itm_subnet.calculate_address_design",
+				args: {
+					network_address: this.state.network_address,
+					prefix_length: this.state.prefix_length,
+				},
+			});
+			this.state.design = r.message;
+			if (r.message) {
+				this.state.network_address = r.message.network_address;
+				this.state.prefix_length = r.message.prefix_length;
+			}
+		} catch (e) {
+			this.state.design = null;
+			return;
+		}
+	}
+
+	render_step() {
+		this.set_footer();
+		const steps_html = this.steps
+			.map(
+				(label, idx) => `
+			<span class="itm-net-wizard__step ${idx === this.step ? "is-active" : ""} ${
+					idx < this.step ? "is-done" : ""
+				}">${idx + 1}. ${label}</span>`
+			)
+			.join("");
+
+		let content = "";
+		if (this.step === 0) {
+			content = this.html_purpose();
+		} else if (this.step === 1) {
+			content = this.html_size();
+		} else if (this.step === 2) {
+			content = this.html_address();
+		} else if (this.step === 3) {
+			content = this.html_infra();
+		} else {
+			content = this.html_review();
+		}
+
+		this.dialog.fields_dict.body.$wrapper.html(`
+			<div class="itm-net-wizard__steps">${steps_html}</div>
+			${content}
+		`);
+
+		if (this.step === 0) {
+			this.lan_control = frappe.ui.form.make_control({
+				parent: this.dialog.fields_dict.body.$wrapper.find(".itm-net-wizard__lan")[0],
+				df: {
+					fieldtype: "Link",
+					options: "ITM Local Area Network",
+					label: __("Local Area Network"),
+					fieldname: "itm_local_area_network",
+					reqd: 1,
+					default: this.state.itm_local_area_network,
+					get_query: () => ({
+						filters: { itm_landscape: this.landscape },
+					}),
+				},
+				render_input: true,
+			});
+			if (this.state.itm_local_area_network) {
+				this.lan_control.set_value(this.state.itm_local_area_network);
+			}
+		}
+
+		if (this.step === 3) {
+			this.role_controls = {};
+			["gateway", "dhcp", "dns_1", "dns_2", "ntp_1", "ntp_2"].forEach((field) => {
+				const label = {
+					gateway: __("Gateway"),
+					dhcp: __("DHCP"),
+					dns_1: __("DNS 1"),
+					dns_2: __("DNS 2"),
+					ntp_1: __("NTP 1"),
+					ntp_2: __("NTP 2"),
+				}[field];
+				const $row = this.dialog.fields_dict.body.$wrapper.find(
+					`.itm-net-wizard__role[data-role="${field}"]`
+				);
+				const ctrl = frappe.ui.form.make_control({
+					parent: $row.find(".itm-net-wizard__role-link")[0],
+					df: {
+						fieldtype: "Link",
+						options: "ITM Host Item",
+						label,
+						fieldname: field,
+						get_query: () => ({
+							filters: { itm_landscape: this.landscape },
+						}),
+					},
+					render_input: true,
+				});
+				if (this.state[field]) {
+					ctrl.set_value(this.state[field]);
+				}
+				this.role_controls[field] = ctrl;
+				$row.find(".itm-net-wizard__role-create").on("click", () => {
+					this.quick_create_host(field, ctrl);
+				});
+			});
+		}
+	}
+
+	html_purpose() {
+		const options = (this.profiles.length
+			? this.profiles
+			: [{ name: "Corporate", label: __("Corporate"), description: "" }]
+		)
+			.map(
+				(p) => `
+			<label style="display:block;margin:0.35rem 0;">
+				<input type="radio" name="purpose_profile" value="${frappe.utils.escape_html(p.name)}" ${
+					p.name === this.state.purpose_profile ? "checked" : ""
+				}/>
+				<strong>${frappe.utils.escape_html(p.label || p.name)}</strong>
+				<span class="text-muted"> — ${frappe.utils.escape_html(p.description || "")}</span>
+			</label>`
+			)
+			.join("");
+
+		return `
+			<p class="itm-net-wizard__hint">${__(
+				"Choose what kind of network you are planning. Suggestions can be changed in later steps."
+			)}</p>
+			${options}
+			<div class="itm-net-wizard__lan" style="margin-top:1rem;"></div>
+		`;
+	}
+
+	html_size() {
+		return `
+			<p class="itm-net-wizard__hint">${__(
+				"How many clients do you expect? We will suggest a prefix with growth headroom."
+			)}</p>
+			<div class="form-group">
+				<label>${__("Expected clients")}</label>
+				<input class="form-control" type="number" min="1" name="expected_clients" value="${
+					this.state.expected_clients || 50
+				}"/>
+			</div>
+			<div class="form-group">
+				<label>${__("Prefix length (optional override)")}</label>
+				<input class="form-control" type="number" min="8" max="32" name="prefix_length" value="${
+					this.state.prefix_length != null ? this.state.prefix_length : ""
+				}" placeholder="${__("Auto")}"/>
+			</div>
+		`;
+	}
+
+	html_address() {
+		const d = this.state.design || {};
+		const conflicts = (this.state.conflicts || [])
+			.map(
+				(c) =>
+					`${frappe.utils.escape_html(c.cidr)} (${frappe.utils.escape_html(
+						c.lifecycle_status || ""
+					)})`
+			)
+			.join(", ");
+		return `
+			<p class="itm-net-wizard__hint">${frappe.utils.escape_html(
+				this.state.profile_notes || ""
+			)}</p>
+			${
+				conflicts
+					? `<div class="itm-net-wizard__warn">${__(
+							"Possible conflicts in this landscape"
+					  )}: ${conflicts}. ${__("Save will warn but not block.")}</div>`
+					: ""
+			}
+			<div class="form-group">
+				<label>${__("Network address")}</label>
+				<input class="form-control" name="network_address" value="${frappe.utils.escape_html(
+					this.state.network_address || d.network_address || ""
+				)}"/>
+			</div>
+			<div class="form-group">
+				<label>${__("Prefix length")}</label>
+				<input class="form-control" type="number" min="0" max="32" name="prefix_length" value="${
+					this.state.prefix_length != null ? this.state.prefix_length : d.prefix_length || 24
+				}"/>
+			</div>
+			<div class="form-group">
+				<label>${__("VLAN tag")}</label>
+				<input class="form-control" type="number" name="vlan_tag" value="${
+					this.state.vlan_tag != null ? this.state.vlan_tag : ""
+				}"/>
+			</div>
+			<pre class="itm-net-wizard__design">${__("Mask")}: ${frappe.utils.escape_html(
+				d.subnet_mask || "—"
+			)}
+${__("CIDR")}: ${frappe.utils.escape_html(d.cidr || "—")}
+${__("Usable")}: ${frappe.utils.escape_html(String(d.first_usable || "—"))} – ${frappe.utils.escape_html(
+				String(d.last_usable || "—")
+			)} (${d.usable_hosts != null ? d.usable_hosts : "—"})</pre>
+		`;
+	}
+
+	html_infra() {
+		const roles = ["gateway", "dhcp", "dns_1", "dns_2", "ntp_1", "ntp_2"];
+		const rows = roles
+			.map(
+				(role) => `
+			<div class="itm-net-wizard__role-row itm-net-wizard__role" data-role="${role}">
+				<div class="itm-net-wizard__role-link"></div>
+				<button type="button" class="btn btn-default btn-sm itm-net-wizard__role-create">${__(
+					"New host"
+				)}</button>
+			</div>`
+			)
+			.join("");
+		return `
+			<p class="itm-net-wizard__hint">${__(
+				"Optionally assign infrastructure hosts. You can create a minimal Host Item inline."
+			)}</p>
+			${rows}
+		`;
+	}
+
+	html_review() {
+		const d = this.state.design || {};
+		return `
+			<p class="itm-net-wizard__hint">${__(
+				"Review and create the subnet as Implementing. Overlaps warn but do not block."
+			)}</p>
+			<pre class="itm-net-wizard__design">${__("Purpose")}: ${frappe.utils.escape_html(
+				this.state.purpose_profile
+			)}
+${__("LAN")}: ${frappe.utils.escape_html(this.state.itm_local_area_network || "")}
+${__("CIDR")}: ${frappe.utils.escape_html(d.cidr || "")}
+${__("VLAN")}: ${this.state.vlan_tag != null ? this.state.vlan_tag : "—"}
+${__("Gateway")}: ${frappe.utils.escape_html(this.state.gateway || "—")}
+${__("DHCP")}: ${frappe.utils.escape_html(this.state.dhcp || "—")}
+${__("DNS")}: ${frappe.utils.escape_html(this.state.dns_1 || "—")} / ${frappe.utils.escape_html(
+				this.state.dns_2 || "—"
+			)}
+${__("NTP")}: ${frappe.utils.escape_html(this.state.ntp_1 || "—")} / ${frappe.utils.escape_html(
+				this.state.ntp_2 || "—"
+			)}</pre>
+		`;
+	}
+
+	quick_create_host(field, ctrl) {
+		const d = new frappe.ui.Dialog({
+			title: __("New Host Item"),
+			fields: [
+				{
+					fieldtype: "Data",
+					fieldname: "title",
+					label: __("Title"),
+					reqd: 1,
+				},
+			],
+			primary_action_label: __("Create"),
+			primary_action: (values) => {
+				frappe.call({
+					method: "it_management.it_management.utils.networking.quick_create_host_item",
+					args: {
+						title: values.title,
+						itm_landscape: this.landscape,
+					},
+					freeze: true,
+					callback: (r) => {
+						if (r.message && r.message.name) {
+							ctrl.set_value(r.message.name);
+							d.hide();
+						}
+					},
+				});
+			},
+		});
+		d.show();
+	}
+
+	async create() {
+		const r = await frappe.call({
+			method: "it_management.it_management.utils.networking.create_subnet_from_wizard",
+			args: {
+				values: {
+					itm_local_area_network: this.state.itm_local_area_network,
+					network_address: this.state.network_address,
+					prefix_length: this.state.prefix_length,
+					vlan_tag: this.state.vlan_tag,
+					gateway: this.state.gateway,
+					dhcp: this.state.dhcp,
+					dns_1: this.state.dns_1,
+					dns_2: this.state.dns_2,
+					ntp_1: this.state.ntp_1,
+					ntp_2: this.state.ntp_2,
+					lifecycle_status: "Implementing",
+					note: __("Created via Plan subnet wizard ({0})", [this.state.purpose_profile]),
+				},
+			},
+			freeze: true,
+			freeze_message: __("Creating subnet…"),
+		});
+		if (!r.message) {
+			return;
+		}
+		this.dialog.hide();
+		frappe.show_alert({
+			message: __("Created subnet {0}", [r.message.cidr || r.message.name]),
+			indicator: "green",
+		});
+		if (this.on_created) {
+			this.on_created(r.message);
+		}
+		frappe.set_route("Form", "ITM Subnet", r.message.name);
+	}
+};

--- a/it_management/workspace_sidebar/it_management.json
+++ b/it_management/workspace_sidebar/it_management.json
@@ -72,6 +72,30 @@
    "icon": "globe",
    "indent": 0,
    "keep_closed": 0,
+   "label": "Networking",
+   "link_to": "Networking",
+   "link_type": "Workspace",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "globe",
+   "indent": 0,
+   "keep_closed": 0,
+   "label": "Networking Overview",
+   "link_to": "it-networking-overview",
+   "link_type": "Page",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 0,
+   "collapsible": 1,
+   "icon": "globe",
+   "indent": 0,
+   "keep_closed": 0,
    "label": "ITM Local Area Network",
    "link_to": "ITM Local Area Network",
    "link_type": "DocType",
@@ -139,7 +163,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-07-18 23:55:00.000000",
+ "modified": "2026-07-19 15:45:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "IT Management",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the **Networking** child workspace with a LAN-centric overview page and a full **Plan new subnet** wizard, per the locked product decisions.

### Decisions implemented
1. Child workspace **Networking** + overview landing page  
2. Overview: Landscape → LANs → subnet utilization bars  
3. Full wizard: Purpose → Size → Address → Infrastructure → Review  
4. Suggestion packs: Corporate, Guest Wi‑Fi, DMZ, Management, IoT  
5. Infra: link existing Host Items + quick-create (roles optional)

### What’s included
- Workspace `Networking` (`parent_page`: IT Management)
- Desk page `it-networking-overview` (utilization + wizard entry)
- API helpers in `it_management.utils.networking`
- Parent workspace / sidebar links into Networking
- Migrate patch `setup_itm_networking_workspace`

### Notes
- Used/free counts use `usable_hosts` vs counted **ITM IP Address** rows (reserved = 0 for now)
- Wizard creates subnets as **Implementing**; overlap/VLAN warnings still come from Subnet validate

### After merge
`bench migrate`, then open **Networking** or **Networking Overview**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

