### PR TITLE
fix: debounce ITM Subnet address validation + octet hints

### DIFF
--- a/it_management/it_management/doctype/itm_subnet/itm_subnet.js
+++ b/it_management/it_management/doctype/itm_subnet/itm_subnet.js
@@ -1,6 +1,15 @@
 // Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 // For license information, please see license.txt
 
+const ITM_SUBNET_ADDRESS_DEBOUNCE_MS = 650;
+
+function itm_subnet_is_complete_ipv4(value) {
+	if (!value) {
+		return false;
+	}
+	return /^\s*\d+\.\d+\.\d+\.\d+\s*$/.test(String(value));
+}
+
 frappe.ui.form.on('ITM Subnet', {
 	setup(frm) {
 		frm.set_query('itm_local_area_network', () => {
@@ -19,11 +28,11 @@ frappe.ui.form.on('ITM Subnet', {
 	},
 
 	network_address(frm) {
-		frm.trigger('recalculate_address_design');
+		frm.trigger('schedule_address_design');
 	},
 
 	prefix_length(frm) {
-		frm.trigger('recalculate_address_design');
+		frm.trigger('schedule_address_design');
 	},
 
 	itm_local_area_network(frm) {
@@ -46,6 +55,24 @@ frappe.ui.form.on('ITM Subnet', {
 		);
 	},
 
+	schedule_address_design(frm) {
+		if (frm._itm_subnet_design_timer) {
+			clearTimeout(frm._itm_subnet_design_timer);
+			frm._itm_subnet_design_timer = null;
+		}
+
+		const address = frm.doc.network_address;
+		// While typing an incomplete address, do not validate or call the server
+		if (address && !itm_subnet_is_complete_ipv4(address)) {
+			return;
+		}
+
+		frm._itm_subnet_design_timer = setTimeout(() => {
+			frm._itm_subnet_design_timer = null;
+			frm.trigger('recalculate_address_design');
+		}, ITM_SUBNET_ADDRESS_DEBOUNCE_MS);
+	},
+
 	recalculate_address_design(frm) {
 		if (
 			!frm.doc.network_address ||
@@ -53,6 +80,10 @@ frappe.ui.form.on('ITM Subnet', {
 			frm.doc.prefix_length === null ||
 			frm.doc.prefix_length === ''
 		) {
+			return;
+		}
+
+		if (!itm_subnet_is_complete_ipv4(frm.doc.network_address)) {
 			return;
 		}
 
@@ -70,10 +101,21 @@ frappe.ui.form.on('ITM Subnet', {
 			freeze: false,
 			callback(r) {
 				frm._itm_subnet_design_busy = false;
-				if (!r.message) {
+				const d = r.message;
+				if (!d) {
 					return;
 				}
-				const d = r.message;
+				if (d.ok === false) {
+					// Soft feedback after a complete address was entered — not while typing
+					frappe.show_alert(
+						{
+							message: d.error || __('Invalid IPv4 network address'),
+							indicator: 'orange',
+						},
+						8
+					);
+					return;
+				}
 				// Update model directly for normalized network to avoid event loops
 				frm.doc.network_address = d.network_address;
 				frm.doc.prefix_length = d.prefix_length;

--- a/it_management/it_management/doctype/itm_subnet/itm_subnet.py
+++ b/it_management/it_management/doctype/itm_subnet/itm_subnet.py
@@ -190,11 +190,15 @@ class ITMSubnet(Document):
 
 @frappe.whitelist()
 def calculate_address_design(network_address=None, prefix_length=None):
-	"""Return derived IPv4 design fields for the Subnet form."""
+	"""
+	Return derived IPv4 design fields for the Subnet form.
+
+	Does not throw on invalid input so live form feedback can stay non-blocking.
+	"""
 	try:
-		return design_from_network_and_prefix(network_address, prefix_length)
+		design = design_from_network_and_prefix(network_address, prefix_length)
 	except (ValueError, TypeError) as exc:
-		frappe.throw(
-			_("Invalid IPv4 network design: {0}").format(str(exc)),
-			title=_("Invalid Subnet"),
-		)
+		return {"ok": False, "error": str(exc)}
+
+	design["ok"] = True
+	return design

--- a/it_management/it_management/utils/ipv4.py
+++ b/it_management/it_management/utils/ipv4.py
@@ -6,6 +6,58 @@
 from __future__ import unicode_literals
 
 import ipaddress
+import re
+
+
+_OCTET_PARTS_RE = re.compile(r"^\s*([0-9]+)\.([0-9]+)\.([0-9]+)\.([0-9]+)\s*$")
+
+
+def explain_ipv4_address_error(network_address):
+	"""
+	Return a user-facing explanation for an invalid IPv4 address, or None if OK.
+
+	Guides on octet ranges (0–255) and dotted-quad shape.
+	"""
+	if network_address in (None, ""):
+		return "Network address is required"
+
+	raw = str(network_address).strip()
+	match = _OCTET_PARTS_RE.match(raw)
+	if not match:
+		return (
+			f"'{raw}' is not a valid IPv4 address. "
+			"Use four numbers separated by dots, e.g. 192.168.0.0. "
+			"Each number (octet) must be between 0 and 255."
+		)
+
+	bad = []
+	for index, part in enumerate(match.groups(), start=1):
+		try:
+			value = int(part)
+		except ValueError:
+			bad.append(f"octet {index} ('{part}') is not a number")
+			continue
+		# Leading zeros like 00 are ok for int(); reject out of range
+		if value < 0 or value > 255:
+			bad.append(
+				f"octet {index} is {value}, but each octet must be between 0 and 255"
+			)
+
+	if bad:
+		return (
+			f"'{raw}' is not a valid IPv4 address: "
+			+ "; ".join(bad)
+			+ ". Example of a valid network address: 192.168.0.0."
+		)
+
+	return None
+
+
+def is_complete_ipv4_address(network_address):
+	"""True when the value has four numeric dotted parts (may still be out of range)."""
+	if network_address in (None, ""):
+		return False
+	return bool(_OCTET_PARTS_RE.match(str(network_address).strip()))
 
 
 def parse_cidr(value):
@@ -25,16 +77,31 @@ def design_from_network_and_prefix(network_address, prefix_length):
 
 	Raises ValueError on invalid input.
 	"""
-	if network_address in (None, ""):
-		raise ValueError("Network address is required")
-	if prefix_length in (None, ""):
-		raise ValueError("Prefix length is required")
+	address_error = explain_ipv4_address_error(network_address)
+	if address_error:
+		raise ValueError(address_error)
 
-	prefix = int(prefix_length)
+	if prefix_length in (None, ""):
+		raise ValueError("Prefix length is required (0–32)")
+
+	try:
+		prefix = int(prefix_length)
+	except (TypeError, ValueError):
+		raise ValueError("Prefix length must be a whole number between 0 and 32")
+
 	if prefix < 0 or prefix > 32:
 		raise ValueError("Prefix length must be between 0 and 32")
 
-	network = ipaddress.ip_network(f"{str(network_address).strip()}/{prefix}", strict=False)
+	try:
+		network = ipaddress.ip_network(
+			f"{str(network_address).strip()}/{prefix}", strict=False
+		)
+	except ValueError as exc:
+		raise ValueError(
+			f"Could not build an IPv4 network from '{network_address}/{prefix}': {exc}. "
+			"Use a dotted IPv4 address (octets 0–255) and a prefix from 0 to 32."
+		) from exc
+
 	return network_to_design(network)
 
 

--- a/it_management/it_management/utils/test_ipv4.py
+++ b/it_management/it_management/utils/test_ipv4.py
@@ -8,6 +8,8 @@ import unittest
 from it_management.it_management.utils.ipv4 import (
 	design_from_cidr,
 	design_from_network_and_prefix,
+	explain_ipv4_address_error,
+	is_complete_ipv4_address,
 	ranges_overlap,
 )
 
@@ -37,3 +39,20 @@ class TestIPv4Design(unittest.TestCase):
 		self.assertFalse(
 			ranges_overlap(a["network_int"], a["broadcast_int"], c["network_int"], c["broadcast_int"])
 		)
+
+	def test_complete_address_detection(self):
+		self.assertFalse(is_complete_ipv4_address("192.168."))
+		self.assertFalse(is_complete_ipv4_address("192.168.1"))
+		self.assertTrue(is_complete_ipv4_address("192.300.0.0"))
+		self.assertTrue(is_complete_ipv4_address("10.0.0.0"))
+
+	def test_octet_range_error_hint(self):
+		message = explain_ipv4_address_error("192.300.0.0")
+		self.assertIsNotNone(message)
+		self.assertIn("300", message)
+		self.assertIn("0 and 255", message)
+
+	def test_invalid_octet_raises_with_hint(self):
+		with self.assertRaises(ValueError) as ctx:
+			design_from_network_and_prefix("192.300.0.0", 24)
+		self.assertIn("0 and 255", str(ctx.exception))

--- a/it_management/public/js/it_networking_overview.js
+++ b/it_management/public/js/it_networking_overview.js
@@ -346,14 +346,19 @@ it_management.networking.PlanSubnetWizard = class PlanSubnetWizard {
 					prefix_length: this.state.prefix_length,
 				},
 			});
-			this.state.design = r.message;
-			if (r.message) {
-				this.state.network_address = r.message.network_address;
-				this.state.prefix_length = r.message.prefix_length;
+			const d = r.message;
+			if (!d || d.ok === false) {
+				this.state.design = null;
+				if (d && d.error) {
+					frappe.show_alert({ message: d.error, indicator: "orange" }, 8);
+				}
+				return;
 			}
+			this.state.design = d;
+			this.state.network_address = d.network_address;
+			this.state.prefix_length = d.prefix_length;
 		} catch (e) {
 			this.state.design = null;
-			return;
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improve live validation UX on **ITM Subnet** network address.

### Changes
- Recalculate only after a **full** dotted IPv4 address is typed (`a.b.c.d`), with a short debounce
- Incomplete input while typing no longer triggers server validation / error dialogs
- Invalid complete addresses (e.g. `192.300.0.0`) return a soft alert naming the bad octet and stating each must be **0–255**
- Document save still hard-validates with the same clearer messages

### After merge
Reload the ITM Subnet form (clear cache / hard refresh if needed).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

