### PR TITLE
refactor: remove Solution Relationships from ITM Solution

### DIFF
--- a/it_management/it_management/doctype/itm_solution/itm_solution.json
+++ b/it_management/it_management/doctype/itm_solution/itm_solution.json
@@ -19,7 +19,6 @@
   "itm_location",
   "section_break_7",
   "description",
-  "itm_solution_table",
   "itm_user_account_table",
   "host_items_section",
   "itm_host_item_solution_table"
@@ -108,12 +107,6 @@
    "options": "ITM Location"
   },
   {
-   "fieldname": "itm_solution_table",
-   "fieldtype": "Table",
-   "label": "Solution Relationships",
-   "options": "ITM Solution Table"
-  },
-  {
    "fieldname": "itm_user_account_table",
    "fieldtype": "Table",
    "hidden": 1,
@@ -135,7 +128,7 @@
   }
  ],
  "links": [],
- "modified": "2026-07-18 22:00:00.000000",
+ "modified": "2026-07-19 17:55:00.000000",
  "modified_by": "Administrator",
  "module": "IT Management",
  "name": "ITM Solution",

--- a/it_management/patches.txt
+++ b/it_management/patches.txt
@@ -20,3 +20,4 @@ it_management.patches.0_4.rename_itm_location_nestedset_fields
 it_management.patches.0_4.migrate_itm_subnet_lan_link
 it_management.patches.0_4.migrate_itm_subnet_address_model
 it_management.patches.0_4.setup_itm_networking_workspace
+it_management.patches.0_4.remove_itm_solution_relationships_table

--- a/it_management/patches/0_4/remove_itm_solution_relationships_table.py
+++ b/it_management/patches/0_4/remove_itm_solution_relationships_table.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+"""
+Remove Solution Relationships child table from ITM Solution.
+
+ITM Solution Table remains — it is still used by ITM User Account.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("DocType", "ITM Solution"):
+		return
+
+	# Drop relationship rows owned by ITM Solution only
+	if frappe.db.table_exists("ITM Solution Table"):
+		frappe.db.sql(
+			"""
+			DELETE FROM `tabITM Solution Table`
+			WHERE parenttype = 'ITM Solution'
+			"""
+		)
+
+	frappe.reload_doc("IT Management", "doctype", "itm_solution", force=True)
+
+	frappe.db.delete(
+		"DocField",
+		{"parent": "ITM Solution", "fieldname": "itm_solution_table"},
+	)
+
+	frappe.clear_cache(doctype="ITM Solution")
+	frappe.db.commit()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the **Solution Relationships** child table from **ITM Solution**.

Relationship / access-path modeling is deferred; this table is not the right place for it.

### Notes
- **ITM Solution Table** DocType is **kept** — it is still used by **ITM User Account** (Solutions link)
- Migrate patch deletes only child rows with `parenttype = 'ITM Solution'`

### After merge
Run `bench migrate`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-006326e0-40c9-4377-91fd-abf48bf8559f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

