### PR TITLE
feat: validate ITM IP Address against linked Subnet

### DIFF
--- a/it_management/it_management/doctype/itm_ip_address/itm_ip_address.js
+++ b/it_management/it_management/doctype/itm_ip_address/itm_ip_address.js
@@ -1,6 +1,73 @@
 // Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
 // For license information, please see license.txt
 
+const ITM_IP_VALIDATE_DEBOUNCE_MS = 450;
+
+function itm_ip_is_complete_ipv4(value) {
+	if (!value) {
+		return false;
+	}
+	return /^\s*\d+\.\d+\.\d+\.\d+\s*$/.test(String(value));
+}
+
 frappe.ui.form.on('ITM IP Address', {
-	// refresh(frm) {}
+	refresh(frm) {
+		frm.trigger('check_ip_against_subnet');
+	},
+
+	ip_address(frm) {
+		frm.trigger('schedule_ip_check');
+	},
+
+	itm_subnet(frm) {
+		frm.trigger('schedule_ip_check');
+	},
+
+	schedule_ip_check(frm) {
+		if (frm._itm_ip_check_timer) {
+			clearTimeout(frm._itm_ip_check_timer);
+			frm._itm_ip_check_timer = null;
+		}
+
+		const ip = frm.doc.ip_address;
+		if (ip && !itm_ip_is_complete_ipv4(ip)) {
+			frm.set_df_property('ip_address', 'description', '');
+			return;
+		}
+
+		frm._itm_ip_check_timer = setTimeout(() => {
+			frm._itm_ip_check_timer = null;
+			frm.trigger('check_ip_against_subnet');
+		}, ITM_IP_VALIDATE_DEBOUNCE_MS);
+	},
+
+	check_ip_against_subnet(frm) {
+		if (!frm.doc.ip_address || !itm_ip_is_complete_ipv4(frm.doc.ip_address)) {
+			frm.set_df_property('ip_address', 'description', '');
+			return;
+		}
+
+		frappe.call({
+			method: 'it_management.it_management.doctype.itm_ip_address.itm_ip_address.validate_ip_for_subnet',
+			args: {
+				ip_address: frm.doc.ip_address,
+				itm_subnet: frm.doc.itm_subnet,
+			},
+			callback(r) {
+				const result = r.message || {};
+				const message = result.message || '';
+				frm.set_df_property('ip_address', 'description', message);
+
+				if (!result.ok && frm.doc.itm_subnet && message) {
+					frm.dashboard.clear_headline();
+					frm.dashboard.set_headline_alert(message, 'red');
+				} else if (result.ok) {
+					frm.dashboard.clear_headline();
+					frm.dashboard.set_headline_alert(message, 'green');
+				} else {
+					frm.dashboard.clear_headline();
+				}
+			},
+		});
+	},
 });

--- a/it_management/it_management/doctype/itm_ip_address/itm_ip_address.json
+++ b/it_management/it_management/doctype/itm_ip_address/itm_ip_address.json
@@ -16,6 +16,7 @@
  ],
  "fields": [
   {
+   "description": "Must be a usable host address inside the selected Subnet (not the network or broadcast address).",
    "fieldname": "ip_address",
    "fieldtype": "Data",
    "in_list_view": 1,

--- a/it_management/it_management/doctype/itm_ip_address/itm_ip_address.py
+++ b/it_management/it_management/doctype/itm_ip_address/itm_ip_address.py
@@ -2,8 +2,113 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+
+from it_management.it_management.utils.ipv4 import (
+	assert_ip_in_subnet,
+	explain_ip_not_in_subnet,
+	parse_ipv4_host,
+)
 
 
 class ITMIPAddress(Document):
-	pass
+	def validate(self):
+		self._normalize_ip_address()
+		self._validate_ip_against_subnet()
+
+	def _normalize_ip_address(self):
+		if not self.ip_address:
+			frappe.throw(_("IP Address is required."), title=_("Invalid IP Address"))
+
+		try:
+			host = parse_ipv4_host(self.ip_address)
+		except ValueError as exc:
+			frappe.throw(str(exc), title=_("Invalid IP Address"))
+
+		# Store the canonical dotted-quad form
+		self.ip_address = str(host)
+
+	def _validate_ip_against_subnet(self):
+		if not self.itm_subnet:
+			frappe.throw(_("Subnet is required."), title=_("Invalid Subnet"))
+
+		subnet = frappe.db.get_value(
+			"ITM Subnet",
+			self.itm_subnet,
+			["name", "network_address", "prefix_length", "cidr", "first_usable", "last_usable"],
+			as_dict=True,
+		)
+		if not subnet:
+			frappe.throw(
+				_("Subnet {0} was not found.").format(self.itm_subnet),
+				title=_("Invalid Subnet"),
+			)
+
+		try:
+			assert_ip_in_subnet(
+				self.ip_address, subnet.network_address, subnet.prefix_length
+			)
+		except ValueError as exc:
+			frappe.throw(str(exc), title=_("IP Not in Subnet"))
+
+
+@frappe.whitelist()
+def validate_ip_for_subnet(ip_address=None, itm_subnet=None):
+	"""
+	Live form check: can this IP be used on the selected ITM Subnet?
+
+	Returns {ok, message, cidr, first_usable, last_usable} and does not throw
+	on membership errors so the form can show feedback while typing.
+	"""
+	result = {
+		"ok": False,
+		"message": "",
+		"cidr": None,
+		"first_usable": None,
+		"last_usable": None,
+		"normalized_ip": None,
+	}
+
+	if not ip_address:
+		result["message"] = _("Enter an IP address.")
+		return result
+
+	try:
+		host = parse_ipv4_host(ip_address)
+	except ValueError as exc:
+		result["message"] = str(exc)
+		return result
+
+	result["normalized_ip"] = str(host)
+
+	if not itm_subnet:
+		result["message"] = _("Select a subnet to check whether this IP can be used.")
+		return result
+
+	subnet = frappe.db.get_value(
+		"ITM Subnet",
+		itm_subnet,
+		["name", "network_address", "prefix_length", "cidr", "first_usable", "last_usable"],
+		as_dict=True,
+	)
+	if not subnet:
+		result["message"] = _("Subnet {0} was not found.").format(itm_subnet)
+		return result
+
+	result["cidr"] = subnet.cidr
+	result["first_usable"] = subnet.first_usable
+	result["last_usable"] = subnet.last_usable
+
+	message = explain_ip_not_in_subnet(
+		str(host), subnet.network_address, subnet.prefix_length
+	)
+	if message:
+		result["message"] = message
+		return result
+
+	result["ok"] = True
+	result["message"] = _("IP address {0} can be used in subnet {1}.").format(
+		str(host), subnet.cidr or subnet.name
+	)
+	return result

--- a/it_management/it_management/doctype/itm_ip_address/test_itm_ip_address.py
+++ b/it_management/it_management/doctype/itm_ip_address/test_itm_ip_address.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026, IT-Geräte und IT-Lösungen wie Server, Rechner, Netzwerke und E-Mailserver sowie auch Backups, and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+import unittest
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from it_management.it_management.doctype.itm_ip_address.itm_ip_address import (
+	validate_ip_for_subnet,
+)
+from it_management.it_management.utils.ipv4 import (
+	assert_ip_in_subnet,
+	explain_ip_not_in_subnet,
+	parse_ipv4_host,
+)
+
+
+class TestIPv4HostInSubnet(unittest.TestCase):
+	def test_parse_host(self):
+		self.assertEqual(str(parse_ipv4_host(" 192.168.1.10 ")), "192.168.1.10")
+
+	def test_host_inside_slash_24(self):
+		self.assertIsNone(explain_ip_not_in_subnet("192.168.1.10", "192.168.1.0", 24))
+		assert_ip_in_subnet("192.168.1.10", "192.168.1.0", 24)
+
+	def test_host_outside_subnet(self):
+		message = explain_ip_not_in_subnet("10.0.0.5", "192.168.1.0", 24)
+		self.assertIsNotNone(message)
+		self.assertIn("outside subnet", message)
+		self.assertIn("192.168.1.0/24", message)
+		with self.assertRaises(ValueError):
+			assert_ip_in_subnet("10.0.0.5", "192.168.1.0", 24)
+
+	def test_rejects_network_and_broadcast(self):
+		network_msg = explain_ip_not_in_subnet("192.168.1.0", "192.168.1.0", 24)
+		self.assertIn("network address", network_msg)
+
+		broadcast_msg = explain_ip_not_in_subnet("192.168.1.255", "192.168.1.0", 24)
+		self.assertIn("broadcast address", broadcast_msg)
+
+	def test_allows_slash_31_endpoints(self):
+		self.assertIsNone(explain_ip_not_in_subnet("10.0.0.0", "10.0.0.0", 31))
+		self.assertIsNone(explain_ip_not_in_subnet("10.0.0.1", "10.0.0.0", 31))
+
+	def test_invalid_ip_message(self):
+		message = explain_ip_not_in_subnet("192.300.1.1", "192.168.1.0", 24)
+		self.assertIn("0 and 255", message)
+
+
+class TestITMIPAddressValidation(FrappeTestCase):
+	def setUp(self):
+		super().setUp()
+		suffix = frappe.generate_hash(length=6)
+		self.landscape = frappe.get_doc(
+			{"doctype": "ITM Landscape", "title": "ITM IP Test Landscape {0}".format(suffix)}
+		).insert(ignore_permissions=True)
+		self.lan = frappe.get_doc(
+			{
+				"doctype": "ITM Local Area Network",
+				"title": "ITM IP Test LAN {0}".format(suffix),
+				"itm_landscape": self.landscape.name,
+			}
+		).insert(ignore_permissions=True)
+		self.subnet = frappe.get_doc(
+			{
+				"doctype": "ITM Subnet",
+				"network_address": "10.55.0.0",
+				"prefix_length": 24,
+				"itm_local_area_network": self.lan.name,
+				"lifecycle_status": "Implementing",
+			}
+		).insert(ignore_permissions=True)
+
+		self.addCleanup(lambda: frappe.delete_doc("ITM Subnet", self.subnet.name, force=1))
+		self.addCleanup(lambda: frappe.delete_doc("ITM Local Area Network", self.lan.name, force=1))
+		self.addCleanup(lambda: frappe.delete_doc("ITM Landscape", self.landscape.name, force=1))
+
+	def test_rejects_ip_outside_subnet(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "ITM IP Address",
+				"ip_address": "192.168.9.9",
+				"itm_subnet": self.subnet.name,
+			}
+		)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			doc.insert(ignore_permissions=True)
+		self.assertIn("outside subnet", str(ctx.exception))
+
+	def test_rejects_network_address(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "ITM IP Address",
+				"ip_address": "10.55.0.0",
+				"itm_subnet": self.subnet.name,
+			}
+		)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			doc.insert(ignore_permissions=True)
+		self.assertIn("network address", str(ctx.exception).lower())
+
+	def test_rejects_broadcast_address(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "ITM IP Address",
+				"ip_address": "10.55.0.255",
+				"itm_subnet": self.subnet.name,
+			}
+		)
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			doc.insert(ignore_permissions=True)
+		self.assertIn("broadcast address", str(ctx.exception).lower())
+
+	def test_accepts_usable_host(self):
+		doc = frappe.get_doc(
+			{
+				"doctype": "ITM IP Address",
+				"ip_address": "10.55.0.42",
+				"itm_subnet": self.subnet.name,
+			}
+		)
+		doc.insert(ignore_permissions=True)
+		self.addCleanup(lambda: frappe.delete_doc("ITM IP Address", doc.name, force=1))
+		self.assertEqual(doc.ip_address, "10.55.0.42")
+
+	def test_whitelist_validate_helper(self):
+		ok = validate_ip_for_subnet("10.55.0.10", self.subnet.name)
+		self.assertTrue(ok["ok"])
+
+		bad = validate_ip_for_subnet("8.8.8.8", self.subnet.name)
+		self.assertFalse(bad["ok"])
+		self.assertIn("outside subnet", bad["message"])

--- a/it_management/it_management/utils/ipv4.py
+++ b/it_management/it_management/utils/ipv4.py
@@ -146,3 +146,86 @@ def network_to_design(network):
 def ranges_overlap(a_start, a_end, b_start, b_end):
 	"""Inclusive integer range overlap."""
 	return a_start <= b_end and b_start <= a_end
+
+
+def parse_ipv4_host(value):
+	"""
+	Parse a host IPv4 address.
+
+	Raises ValueError with a user-facing message when invalid.
+	"""
+	address_error = explain_ipv4_address_error(value)
+	if address_error:
+		# explain_ipv4_address_error says "Network address" for empty — rephrase for hosts
+		if value in (None, ""):
+			raise ValueError("IP address is required")
+		raise ValueError(address_error.replace("network address", "IP address", 1))
+
+	try:
+		host = ipaddress.ip_address(str(value).strip())
+	except ValueError as exc:
+		raise ValueError(
+			"'{0}' is not a valid IPv4 address. "
+			"Use four numbers separated by dots, e.g. 192.168.1.10.".format(str(value).strip())
+		) from exc
+
+	if host.version != 4:
+		raise ValueError("Only IPv4 addresses are supported")
+
+	return host
+
+
+def explain_ip_not_in_subnet(ip_address, network_address, prefix_length):
+	"""
+	Return a user-facing error if the host IP cannot be used in the subnet.
+
+	Returns None when the IP is a usable host address in the subnet.
+	Network and broadcast addresses are rejected for prefixes shorter than /31.
+	"""
+	try:
+		host = parse_ipv4_host(ip_address)
+	except ValueError as exc:
+		return str(exc)
+
+	try:
+		design = design_from_network_and_prefix(network_address, prefix_length)
+	except ValueError as exc:
+		return "Linked subnet is invalid: {0}".format(str(exc))
+
+	network = ipaddress.ip_network(design["cidr"], strict=False)
+	if host not in network:
+		return (
+			"IP address {0} is outside subnet {1}. "
+			"Usable host range is {2} – {3}."
+		).format(
+			host,
+			design["cidr"],
+			design["first_usable"],
+			design["last_usable"],
+		)
+
+	# /31 and /32 treat both addresses as usable
+	if network.prefixlen >= 31:
+		return None
+
+	if host == network.network_address:
+		return (
+			"IP address {0} is the network address of {1} and cannot be assigned to a host. "
+			"Use an address from {2} to {3}."
+		).format(host, design["cidr"], design["first_usable"], design["last_usable"])
+
+	if host == network.broadcast_address:
+		return (
+			"IP address {0} is the broadcast address of {1} and cannot be assigned to a host. "
+			"Use an address from {2} to {3}."
+		).format(host, design["cidr"], design["first_usable"], design["last_usable"])
+
+	return None
+
+
+def assert_ip_in_subnet(ip_address, network_address, prefix_length):
+	"""Raise ValueError when the host IP is not usable in the subnet."""
+	message = explain_ip_not_in_subnet(ip_address, network_address, prefix_length)
+	if message:
+		raise ValueError(message)
+	return True

--- a/it_management/it_management/utils/test_ipv4.py
+++ b/it_management/it_management/utils/test_ipv4.py
@@ -56,3 +56,18 @@ class TestIPv4Design(unittest.TestCase):
 		with self.assertRaises(ValueError) as ctx:
 			design_from_network_and_prefix("192.300.0.0", 24)
 		self.assertIn("0 and 255", str(ctx.exception))
+
+	def test_host_membership_in_subnet(self):
+		from it_management.it_management.utils.ipv4 import (
+			assert_ip_in_subnet,
+			explain_ip_not_in_subnet,
+		)
+
+		self.assertIsNone(explain_ip_not_in_subnet("192.168.1.10", "192.168.1.0", 24))
+		outside = explain_ip_not_in_subnet("10.0.0.5", "192.168.1.0", 24)
+		self.assertIn("outside subnet", outside)
+		self.assertIn("network address", explain_ip_not_in_subnet("192.168.1.0", "192.168.1.0", 24))
+		self.assertIn("broadcast address", explain_ip_not_in_subnet("192.168.1.255", "192.168.1.0", 24))
+		self.assertIsNone(explain_ip_not_in_subnet("10.0.0.0", "10.0.0.0", 31))
+		with self.assertRaises(ValueError):
+			assert_ip_in_subnet("8.8.8.8", "192.168.0.0", 24)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Validates **ITM IP Address** against its linked **ITM Subnet** on save. Invalid IPs cannot be saved; the form also shows live feedback while editing.

### Rules
- IP must be a valid IPv4 address
- IP must fall inside the subnet CIDR (`network_address` + `prefix_length`)
- Network and broadcast addresses are rejected for prefixes shorter than `/31` (they are not usable hosts)
- `/31` and `/32` allow both endpoint addresses (point-to-point)

### UX
- Clear validation errors on save (title: **IP Not in Subnet** / **Invalid IP Address**)
- Debounced live check on the form with green/red headline when IP + Subnet are set
- Field description updated to describe the usable-host rule

### Implementation
- Reuses existing `ipv4` helpers; adds `parse_ipv4_host`, `explain_ip_not_in_subnet`, `assert_ip_in_subnet`
- `ITMIPAddress.validate()` enforces the rules server-side
- Whitelisted `validate_ip_for_subnet` for non-blocking form feedback

## Test plan
- [ ] Create an ITM Subnet e.g. `10.55.0.0/24`
- [ ] Create ITM IP Address `10.55.0.42` on that subnet → save succeeds
- [ ] Try `192.168.9.9` on that subnet → save blocked with “outside subnet”
- [ ] Try `10.55.0.0` (network) → blocked
- [ ] Try `10.55.0.255` (broadcast) → blocked
- [ ] Confirm form shows green/red feedback when changing IP or Subnet
- [ ] Optional: `bench run-tests --app it_management --module it_management.it_management.doctype.itm_ip_address.test_itm_ip_address`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4febb2b4-30c5-4dd6-a994-8e8002e4f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4febb2b4-30c5-4dd6-a994-8e8002e4f42a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

